### PR TITLE
Add PDB, MAP and FV directories in artifacts

### DIFF
--- a/.github/workflows/Platform-Build.yml
+++ b/.github/workflows/Platform-Build.yml
@@ -77,18 +77,12 @@ jobs:
         run: |
           stuart_build -c MsvmPkg/PlatformBuild.py TOOL_CHAIN_TAG=VS2022 TARGET=${{ matrix.target }} BUILD_ARCH=${{ matrix.arch }}
 
-      # Archive only the FV/, MAP/, and PDB/ directories into a zip file
-      - name: Archive Selected Directories
-        run: |
-          Compress-Archive -Path "Build/Msvm${{ matrix.arch }}/${{ matrix.target }}_VS2022/FV", `
-                                 "Build/Msvm${{ matrix.arch }}/${{ matrix.target }}_VS2022/MAP", `
-                                 "Build/Msvm${{ matrix.arch }}/${{ matrix.target }}_VS2022/PDB" `
-                         -DestinationPath "Build/Msvm${{ matrix.arch }}/${{ matrix.target }}_VS2022/${{ matrix.target }}-${{ matrix.arch }}-artifacts.zip"
-        shell: pwsh
-
-      # Upload the zip file as an artifact
+      # Upload the MSVM.fd file, MAP/, and PDB/ directories directly as an artifact
       - name: Upload Build Artifact
         uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.target }}-${{ matrix.arch }}-artifacts
-          path: Build/Msvm${{ matrix.arch }}/${{ matrix.target }}_VS2022/${{ matrix.target }}-${{ matrix.arch }}-artifacts.zip
+          path: |
+            Build/Msvm${{ matrix.arch }}/${{ matrix.target }}_VS2022/FV/MSVM.fd
+            Build/Msvm${{ matrix.arch }}/${{ matrix.target }}_VS2022/MAP/
+            Build/Msvm${{ matrix.arch }}/${{ matrix.target }}_VS2022/PDB/

--- a/.github/workflows/Platform-Build.yml
+++ b/.github/workflows/Platform-Build.yml
@@ -77,9 +77,18 @@ jobs:
         run: |
           stuart_build -c MsvmPkg/PlatformBuild.py TOOL_CHAIN_TAG=VS2022 TARGET=${{ matrix.target }} BUILD_ARCH=${{ matrix.arch }}
 
-      # Upload the MSVM.fd build artifact, categorized by arch and target
-      - name: Upload MSVM.fd Artifact
+      # Archive only the FV/, MAP/, and PDB/ directories into a zip file
+      - name: Archive Selected Directories
+        run: |
+          Compress-Archive -Path "Build/Msvm${{ matrix.arch }}/${{ matrix.target }}_VS2022/FV", `
+                                 "Build/Msvm${{ matrix.arch }}/${{ matrix.target }}_VS2022/MAP", `
+                                 "Build/Msvm${{ matrix.arch }}/${{ matrix.target }}_VS2022/PDB" `
+                         -DestinationPath "Build/Msvm${{ matrix.arch }}/${{ matrix.target }}_VS2022/${{ matrix.target }}-${{ matrix.arch }}-artifacts.zip"
+        shell: pwsh
+
+      # Upload the zip file as an artifact
+      - name: Upload Build Artifact
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ matrix.target }}-${{ matrix.arch }}
-          path: Build/Msvm${{ matrix.arch }}/${{ matrix.target }}_VS2022/FV/MSVM.fd
+          name: ${{ matrix.target }}-${{ matrix.arch }}-artifacts
+          path: Build/Msvm${{ matrix.arch }}/${{ matrix.target }}_VS2022/${{ matrix.target }}-${{ matrix.arch }}-artifacts.zip


### PR DESCRIPTION
This PR ensures that PDB/, MAP/ and the FV/ folder (FV contains MSVM.fd) are included in the artifacts