### PR TITLE
Fix escape character warning when using PlatformB…

### DIFF
--- a/MsvmPkg/PlatformBuild.py
+++ b/MsvmPkg/PlatformBuild.py
@@ -113,11 +113,11 @@ class PlatformBuilder(UefiBuilder, UpdateSettingsManager, SetupSettingsManager, 
         from edk2toolext.invocables.edk2_setup import Edk2PlatformSetup
         from edk2toolext.invocables.edk2_platform_build import Edk2PlatformBuild
         print("Invoking Stuart")
-        print("     ) _     _")
-        print("    ( (^)-~-(^)")
-        print("__,-.\_( 0 0 )__,-.___")
-        print("  'W'   \   /   'W'")
-        print("         >o<")
+        print(r"     ) _     _")
+        print(r"    ( (^)-~-(^)")
+        print(r"__,-.\_( 0 0 )__,-.___")
+        print(r"  'W'   \   /   'W'")
+        print(r"         >o<")
         SCRIPT_PATH = os.path.relpath(__file__)
         parser = argparse.ArgumentParser(add_help=False)
         parse_group = parser.add_mutually_exclusive_group()


### PR DESCRIPTION
…uild.py

Use raw strings instead of regular strings in our PlatformBuild.py. Otherwise, you will keep seeing this when you build:

```
C:\projects\hyperv.uefi\MsvmPkg\PlatformBuild.py:119: SyntaxWarning: invalid escape sequence '\_'
  print("__,-.\_( 0 0 )__,-.___")
C:\projects\hyperv.uefi\MsvmPkg\PlatformBuild.py:120: SyntaxWarning: invalid escape sequence '\ '
  print("  'W'   \   /   'W'")
```

----
#### AI description  (iteration 1)
#### PR Classification
Bug fix

#### PR Summary
This pull request addresses a warning related to escape characters in `PlatformBuild.py`.
- `MsvmPkg/PlatformBuild.py`: Added raw string literals to fix escape character warnings in print statements.

Related work items: #54513279