### PR TITLE
Enable strict S4 check across arm64 and amd64

### DIFF
--- a/MsvmPkg/AcpiTables/Dsdt.asl
+++ b/MsvmPkg/AcpiTables/Dsdt.asl
@@ -89,8 +89,6 @@ DefinitionBlock (
         Name(\_S4, Package(2){1, 0})
     }
 
-#if defined(_DSDT_ARM_)
-
     Scope(\_SB)
     {
         // ARM needs to use the strict check to determine if the hibernate state is present.
@@ -146,8 +144,6 @@ DefinitionBlock (
             }
         }
     }
-
-#endif
 
 
 


### PR DESCRIPTION
Updated Dsdt.asl to enable strict S4 check across arm64 and amd64

#### PR Summary
This pull request enables strict S4 checks across both arm64 and amd64 architectures by removing architecture-specific conditional compilation.
- `MsvmPkg/AcpiTables/Dsdt.asl`: Removed conditional compilation directives for ARM, ensuring strict S4 checks are applied universally.
