### PR TITLE
VmBus: support confidential external memory on CVM.

### DIFF
--- a/MsvmPkg/Include/Protocol/Vmbus.h
+++ b/MsvmPkg/Include/Protocol/Vmbus.h
@@ -11,21 +11,26 @@
 #define EFI_VMBUS_PROTOCOL_FLAGS_PIPE_MODE  0x1
 
 //
+// Indicates that the channel is offered by the paravisor, and must use
+// encrypted memory for additional GPADLs and GPA direct packets.
+//
+
+#define EFI_VMBUS_PROTOCOL_FLAGS_CONFIDENTIAL_EXTERNAL_MEMORY 0x2
+
+//
 // Zero all memory in the buffer used for the GPADL.
 //
 
 #define EFI_VMBUS_PREPARE_GPADL_FLAG_ZERO_PAGES      0x1
 
 //
-// Indicates that the GPADL buffer may be in encrypted memory on a hardware
-// isolated VM, if the channel is confidential. If the channel is not
-// confidential, or hardware isolation is not in use, the flag has no effect.
+// Indicates that the GPADL buffer is to be used for a ring buffer.
 //
 
-#define EFI_VMBUS_PREPARE_GPADL_FLAG_ALLOW_ENCRYPTED 0x2
+#define EFI_VMBUS_PREPARE_GPADL_FLAG_RING_BUFFER 0x2
 #define EFI_VMBUS_PREPARE_GPADL_FLAGS \
     (EFI_VMBUS_PREPARE_GPADL_FLAG_ZERO_PAGES | \
-     EFI_VMBUS_PREPARE_GPADL_FLAG_ALLOW_ENCRYPTED)
+     EFI_VMBUS_PREPARE_GPADL_FLAG_RING_BUFFER)
 
 typedef struct _EFI_VMBUS_PROTOCOL EFI_VMBUS_PROTOCOL;
 typedef struct _EFI_VMBUS_LEGACY_PROTOCOL EFI_VMBUS_LEGACY_PROTOCOL;

--- a/MsvmPkg/VmbusDxe/ChannelMessages.h
+++ b/MsvmPkg/VmbusDxe/ChannelMessages.h
@@ -131,9 +131,12 @@ typedef struct _VMBUS_CHANNEL_MESSAGE_HEADER
 //
 
 #define VMBUS_OFFER_FLAG_ENUMERATE_DEVICE_INTERFACE     0x1
-// This flag indicates that the channel is offered by the paravisor, and may
+// This flag indicates that the channel is offered by the paravisor, and must
 // use encrypted memory for the channel ring buffer.
-#define VMBUS_OFFER_FLAG_CONFIDENTIAL_CHANNEL           0x2
+#define VMBUS_OFFER_FLAG_CONFIDENTIAL_RING_BUFFER       0x2
+// This flag indicates that the channel is offered by the paravisor, and must
+// use encrypted memory for GPA direct packets and additional GPADLs.
+#define VMBUS_OFFER_FLAG_CONFIDENTIAL_EXTERNAL_MEMORY   0x4
 #define VMBUS_OFFER_FLAG_NAMED_PIPE_MODE                0x10
 #define VMBUS_OFFER_FLAG_TLNPI_PROVIDER                 0x2000
 

--- a/MsvmPkg/VmbusDxe/VmbusP.h
+++ b/MsvmPkg/VmbusDxe/VmbusP.h
@@ -194,10 +194,13 @@ typedef struct _VMBUS_CHANNEL_CONTEXT
 
     //
     // A confidential channel is a channel offered by the paravisor on a
-    // hardware-isolated VM, which means it can use encrypted memory for the
-    // ring buffer.
+    // hardware-isolated VM, which means it must use encrypted memory for the
+    // ring buffer and/or additional GPADLs and GPA direct.
     //
-    BOOLEAN Confidential;
+    // N.B. Whether or not confidential external memory is supported is
+    //      indicated in VmbusProtocol.Flags.
+    //
+    BOOLEAN ConfidentialRing;
 
 } VMBUS_CHANNEL_CONTEXT;
 


### PR DESCRIPTION
This change adds VmBus client support for an additional offer flag that indicates memory other than the ring buffer must also be encrypted. If this flag is present, any additional GPADLs are not made host visible, and bounce buffering is disabled for GPA direct packets.

Support for this offer flag is indicated by the same feature flag that was already used for encrypted ring buffers.  OpenHCL can set these flags when appropriate when running on a hardware-isolated VM.