### PR TITLE
Add support for consuming IORT table

### DIFF
--- a/MsvmPkg/AcpiPlatformDxe/AcpiPlatformDxe.inf
+++ b/MsvmPkg/AcpiPlatformDxe/AcpiPlatformDxe.inf
@@ -76,6 +76,8 @@
     gMsvmPkgTokenSpaceGuid.PcdMcfgSize                          ## CONSUMES
     gMsvmPkgTokenSpaceGuid.PcdSsdtPtr                           ## CONSUMES
     gMsvmPkgTokenSpaceGuid.PcdSsdtSize                          ## CONSUMES
+    gMsvmPkgTokenSpaceGuid.PcdIortPtr                           ## CONSUMES
+    gMsvmPkgTokenSpaceGuid.PcdIortSize                          ## CONSUMES
     gMsvmPkgTokenSpaceGuid.PcdNvdimmCount                       ## CONSUMES
     gMsvmPkgTokenSpaceGuid.PcdPpttPtr                           ## CONSUMES
     gMsvmPkgTokenSpaceGuid.PcdPpttSize                          ## CONSUMES

--- a/MsvmPkg/Include/BiosInterface.h
+++ b/MsvmPkg/Include/BiosInterface.h
@@ -552,6 +552,7 @@ enum UefiStructureType
     UefiConfigMcfg                           = 0x24,
     UefiConfigSsdt                           = 0x25,
     UefiConfigHmat                           = 0x26,
+    UefiConfigIort                           = 0x27,
 };
 
 //
@@ -862,6 +863,12 @@ typedef struct _UEFI_CONFIG_SSDT
     UEFI_CONFIG_HEADER Header;
     UINT8 Ssdt[];
 } UEFI_CONFIG_SSDT;
+
+typedef struct _UEFI_CONFIG_IORT
+{
+    UEFI_CONFIG_HEADER Header;
+    UINT8 Iort[];
+} UEFI_CONFIG_IORT;
 
 //
 // UEFI configuration information for direct parsing of IGVM parameters.

--- a/MsvmPkg/MsvmPkg.dec
+++ b/MsvmPkg/MsvmPkg.dec
@@ -363,3 +363,7 @@
   # UEFI_CONFIG_SSDT
   gMsvmPkgTokenSpaceGuid.PcdSsdtPtr|0x0|UINT64|0x606C
   gMsvmPkgTokenSpaceGuid.PcdSsdtSize|0x0|UINT32|0x606D
+
+  # UEFI_CONFIG_IORT
+  gMsvmPkgTokenSpaceGuid.PcdIortPtr|0x0|UINT64|0x6070
+  gMsvmPkgTokenSpaceGuid.PcdIortSize|0x0|UINT32|0x6071

--- a/MsvmPkg/MsvmPkgAARCH64.dsc
+++ b/MsvmPkg/MsvmPkgAARCH64.dsc
@@ -531,6 +531,10 @@
   gMsvmPkgTokenSpaceGuid.PcdHmatPtr|0x0
   gMsvmPkgTokenSpaceGuid.PcdHmatSize|0x0
 
+  # UEFI_CONFIG_IORT
+  gMsvmPkgTokenSpaceGuid.PcdIortPtr|0x0
+  gMsvmPkgTokenSpaceGuid.PcdIortSize|0x0
+
   # UEFI_CONFIG_MEMORY_MAP
   gMsvmPkgTokenSpaceGuid.PcdMemoryMapPtr|0x0
   gMsvmPkgTokenSpaceGuid.PcdMemoryMapSize|0x0

--- a/MsvmPkg/MsvmPkgX64.dsc
+++ b/MsvmPkg/MsvmPkgX64.dsc
@@ -532,6 +532,10 @@
   gMsvmPkgTokenSpaceGuid.PcdHmatPtr|0x0
   gMsvmPkgTokenSpaceGuid.PcdHmatSize|0x0
 
+  # UEFI_CONFIG_IORT
+  gMsvmPkgTokenSpaceGuid.PcdIortPtr|0x0
+  gMsvmPkgTokenSpaceGuid.PcdIortSize|0x0
+
   # UEFI_CONFIG_MEMORY_MAP
   gMsvmPkgTokenSpaceGuid.PcdMemoryMapPtr|0x0
   gMsvmPkgTokenSpaceGuid.PcdMemoryMapSize|0x0

--- a/MsvmPkg/PlatformPei/Config.c
+++ b/MsvmPkg/PlatformPei/Config.c
@@ -772,6 +772,10 @@ DebugDumpUefiConfigStruct(
             DEBUG((DEBUG_VERBOSE, "\tSSDT table found.\n"));
             break;
 
+        case UefiConfigIort:
+            DEBUG((DEBUG_VERBOSE, "\tIORT table found.\n"));
+            break;
+
         default:
             DEBUG((DEBUG_VERBOSE, "\t!!! Unrecognized config structure type !!!\n"));
             break;
@@ -1052,6 +1056,7 @@ Return Value:
         0, //UefiConfigMcfg
         0, //UefiConfigSsdt
         0, //UefiConfigHmat
+        0, //UefiConfigIort
     };
 
     //
@@ -1601,6 +1606,21 @@ Return Value:
                 PEI_FAIL_FAST_IF_FAILED(PcdSet32S(PcdSsdtSize, ssdtHdr->Length));
                 break;
 
+            case UefiConfigIort:
+                UEFI_CONFIG_IORT *iortStructure = (UEFI_CONFIG_IORT*) header;
+                EFI_ACPI_DESCRIPTION_HEADER *iortHdr = (EFI_ACPI_DESCRIPTION_HEADER*) iortStructure->Iort;
+
+                if (iortStructure->Header.Length < (sizeof(UEFI_CONFIG_HEADER) + sizeof(EFI_ACPI_DESCRIPTION_HEADER)) ||
+                    iortHdr->Signature != EFI_ACPI_6_2_IO_REMAPPING_TABLE_SIGNATURE ||
+                    iortHdr->Length > (iortStructure->Header.Length - sizeof(UEFI_CONFIG_HEADER)))
+                {
+                    DEBUG((DEBUG_ERROR, "*** Malformed IORT\n"));
+                    FAIL_FAST_UNEXPECTED_HOST_BEHAVIOR();
+                }
+
+                PEI_FAIL_FAST_IF_FAILED(PcdSet64S(PcdIortPtr, (UINT64)iortStructure->Iort));
+                PEI_FAIL_FAST_IF_FAILED(PcdSet32S(PcdIortSize, iortHdr->Length));
+                break;
         }
 
         calculatedConfigSize += header->Length;

--- a/MsvmPkg/PlatformPei/PlatformPei.inf
+++ b/MsvmPkg/PlatformPei/PlatformPei.inf
@@ -84,6 +84,8 @@
     gMsvmPkgTokenSpaceGuid.PcdDxeFvSize
     gMsvmPkgTokenSpaceGuid.PcdConfigBlobSize
     gMsvmPkgTokenSpaceGuid.PcdLegacyMemoryMap
+    gMsvmPkgTokenSpaceGuid.PcdIortPtr
+    gMsvmPkgTokenSpaceGuid.PcdIortSize
     gMsvmPkgTokenSpaceGuid.PcdMadtPtr
     gMsvmPkgTokenSpaceGuid.PcdMadtSize
     gMsvmPkgTokenSpaceGuid.PcdMcfgPtr


### PR DESCRIPTION
Add support for consuming IORT table

----
#### AI description  (iteration 1)
#### PR Classification
New feature

#### PR Summary
This pull request adds support for consuming the IORT (IO Remapping Table) in the ACPI (Advanced Configuration and Power Interface) tables.
- `MsvmPkg/AcpiPlatformDxe/AcpiPlatform.c`: Added function `AcpiInstallIortTable` to install the IORT table.
- `MsvmPkg/PlatformPei/Config.c`: Added handling for IORT configuration and updated debug output.
- `MsvmPkg/Include/BiosInterface.h`: Defined new structure `UEFI_CONFIG_IORT` and added `UefiConfigIort` to `UefiStructureType` enum.
- Updated `.dsc`, `.inf`, and `.dec` files to include IORT-related PCDs (Platform Configuration Database entries).

#### Test
Tested with loading the private MSVM.fd on GH200 and verified using debugger that a guest can see the IORT table:
```
kd> !iort
IORT - HEADER - fffff7f400010018
  Signature:               IORT
  Length:                  0x00000030
  Revision:                0x06
  Checksum:                0xdb
  OEMID:                   VRTUAL
  OEMTableID:              MICROSFT
  OEMRevision:             0x00000001
  CreatorID:               MSFT
  CreatorRev:              0x00000001
IORT - BODY - fffff7f40001003c
-----------------------------------------------------
   NodeCount : 0x00000000
   NodeArrayOffset : 0x00000030
```

Related work items: #54083063