### PR TITLE
Finish wiring MtrrsInitializedAtLoad for OpenHCL support (#19)

### DIFF
--- a/MsvmPkg/CpuDxe/CpuDxe.c
+++ b/MsvmPkg/CpuDxe/CpuDxe.c
@@ -760,6 +760,10 @@ RefreshMemoryAttributesFromMtrr (
   // PcdMtrrsInitializedAtLoad will be set iff the virtualization stack has correctly
   // initialized MTRRs before UEFI runs
   //
+  // N.B. this below upstream logic can only be enabled when OpenVMM sets MTRRs in an
+  //   architecturally-correct way (not with Hyper-V compatibility).  Until then,
+  //   also fall back to Hyper-V specific code that can deal with the peculiar MTRRs.
+  /*
   if (PcdGetBool(PcdMtrrsInitializedAtLoad))
   {
     RETURN_STATUS                    ReturnStatus;
@@ -786,6 +790,7 @@ RefreshMemoryAttributesFromMtrr (
   }
   else
   {
+  */
     UINTN                            SubIndex;
     UINT64                           RegValue;
     EFI_PHYSICAL_ADDRESS             BaseAddress;
@@ -940,7 +945,7 @@ RefreshMemoryAttributesFromMtrr (
       Length,
       Attributes
       );
-  }
+  //}
   // MS_HYP_CHANGE END
 
   //

--- a/MsvmPkg/Include/BiosInterface.h
+++ b/MsvmPkg/Include/BiosInterface.h
@@ -782,7 +782,8 @@ typedef struct _UEFI_CONFIG_FLAGS
         UINT64 TpmLocalityRegsEnabled : 1;
         UINT64 Dhcp6DuidTypeLlt : 1;
         UINT64 CxlMemoryEnabled : 1;
-        UINT64 Reserved:36;
+        UINT64 MtrrsInitializedAtLoad : 1;
+        UINT64 Reserved:35;
     } Flags;
 } UEFI_CONFIG_FLAGS;
 

--- a/MsvmPkg/PlatformPei/Config.c
+++ b/MsvmPkg/PlatformPei/Config.c
@@ -730,6 +730,7 @@ DebugDumpUefiConfigStruct(
             DEBUG((DEBUG_VERBOSE, "\tMemoryProtectionMode: %u\n", flags->Flags.MemoryProtectionMode));
             DEBUG((DEBUG_VERBOSE, "\tWatchdogEnabled: %u\n", flags->Flags.WatchdogEnabled));
             DEBUG((DEBUG_VERBOSE, "\tTpmLocalityRegsEnabled: %u\n", flags->Flags.TpmLocalityRegsEnabled));
+            DEBUG((DEBUG_VERBOSE, "\tMtrrsInitializedAtLoad: %u\n", flags->Flags.MtrrsInitializedAtLoad));
             break;
 
         case UefiConfigProcessorInformation:
@@ -895,6 +896,7 @@ ConfigSetUefiConfigFlags(
     PEI_FAIL_FAST_IF_FAILED(PcdSetBoolS(PcdMediaPresentEnabledByDefault, (UINT8) ConfigFlags->Flags.MediaPresentEnabledByDefault));
     PEI_FAIL_FAST_IF_FAILED(PcdSetBoolS(PcdWatchdogEnabled, (UINT8) ConfigFlags->Flags.WatchdogEnabled));
     PEI_FAIL_FAST_IF_FAILED(PcdSetBoolS(PcdTpmLocalityRegsEnabled, (UINT8) ConfigFlags->Flags.TpmLocalityRegsEnabled));
+    PEI_FAIL_FAST_IF_FAILED(PcdSetBoolS(PcdMtrrsInitializedAtLoad, (UINT8) ConfigFlags->Flags.MtrrsInitializedAtLoad));
 
     //
     // If memory protections are enabled, configure the value into the HOB.

--- a/MsvmPkg/PlatformPei/Platform.c
+++ b/MsvmPkg/PlatformPei/Platform.c
@@ -676,7 +676,6 @@ Return Value:
 
 #if defined (MDE_CPU_X64)
 
-
     if (!PcdGetBool(PcdMtrrsInitializedAtLoad))
     {
         //


### PR DESCRIPTION
* Finish wiring MtrrsInitializedAtLoad for OpenHCL support

* CpuDxe should always use legacy MTRR handling for now