### PR TITLE
Merged PR 12666252: Send GPA of advanced logger to the host

### DIFF
--- a/MsvmPkg/Include/BiosInterface.h
+++ b/MsvmPkg/Include/BiosInterface.h
@@ -89,6 +89,11 @@ enum
     //
     BiosConfigMemoryMapSize             = 0x2A,
     //
+    // EFI Diagnostics (set by UEFI firmware)
+    //
+    BiosConfigSetEfiDiagnosticsGpa      = 0x2B,
+    BiosConfigProcessEfiDiagnostics     = 0x2C,
+    //
     // Event Logging (Windows 8.1 MQ/M0)
     //
     BiosConfigEventLogFlush             = 0x30,

--- a/MsvmPkg/Library/CrashLib/AArch64/Crash.c
+++ b/MsvmPkg/Library/CrashLib/AArch64/Crash.c
@@ -9,10 +9,12 @@
 #include <IndustryStandard/ArmStdSmc.h>
 #include <Library/ArmSmcLib.h>
 #include <Library/BaseLib.h>
+#include <Library/BiosDeviceLib.h>
 #include <Library/DebugLib.h>
 #include <Library/HvHypercallLib.h>
 #include <Hv/HvGuestCpuid.h>
 #include <Hv/HvGuestMsr.h>
+#include <BiosInterface.h>
 
 #include "CrashLibConstants.h"
 
@@ -122,4 +124,10 @@ ReportCrash(
 
     AsmSetVpRegister64(HvRegisterGuestCrashCtl, writeCrashCtlReg.AsUINT64);
     DEBUG((EFI_D_INFO, "ReportCrash successful.\n"));
+
+    //
+    // Tell the host to collect EFI diagnostics.
+    //
+    DEBUG((EFI_D_INFO, "Signaling BIOS device to collect EFI diagnostics...\n"));
+    WriteBiosDevice(BiosConfigProcessEfiDiagnostics, TRUE);
 }

--- a/MsvmPkg/Library/CrashLib/CrashLib.inf
+++ b/MsvmPkg/Library/CrashLib/CrashLib.inf
@@ -34,6 +34,7 @@
 
 [LibraryClasses]
   BaseLib
+  BiosDeviceLib
   DebugLib
   PrintLib
 

--- a/MsvmPkg/Library/CrashLib/X64/Crash.c
+++ b/MsvmPkg/Library/CrashLib/X64/Crash.c
@@ -7,9 +7,11 @@
 
 #include <Uefi.h>
 #include <Library/BaseLib.h>
+#include <Library/BiosDeviceLib.h>
 #include <Library/DebugLib.h>
 #include <Hv/HvGuestCpuid.h>
 #include <Hv/HvGuestMsr.h>
+#include <BiosInterface.h>
 
 #include "CrashLibConstants.h"
 
@@ -104,4 +106,10 @@ ReportCrash(
 
     AsmWriteMsr64(HvSyntheticMsrCrashCtl, writeCrashCtlReg.AsUINT64);
     DEBUG((EFI_D_INFO, "ReportCrash successful.\n"));
+
+    //
+    // Tell the host to collect EFI diagnostics.
+    //
+    DEBUG((EFI_D_INFO, "Signaling BIOS device to collect EFI diagnostics...\n"));
+    WriteBiosDevice(BiosConfigProcessEfiDiagnostics, TRUE);
 }

--- a/MsvmPkg/Library/DeviceBootManagerLib/DeviceBootManagerLib.c
+++ b/MsvmPkg/Library/DeviceBootManagerLib/DeviceBootManagerLib.c
@@ -12,6 +12,7 @@
 #include <Protocol/SimpleFileSystem.h>
 
 #include <Library/BaseMemoryLib.h>
+#include <Library/BiosDeviceLib.h>
 #include <Library/DebugLib.h>
 #include <Library/DeviceBootManagerLib.h>
 #include <Library/DevicePathLib.h>
@@ -25,6 +26,7 @@
 #include <Library/PcdLib.h>
 #include <Library/UefiBootServicesTableLib.h>
 #include <Library/UefiLib.h>
+#include <BiosInterface.h>
 
 #include <VirtualDeviceId.h>
 
@@ -676,6 +678,12 @@ DeviceBootManagerUnableToBoot (
             // }
         }
     }
+
+    //
+    // Tell the host to collect EFI diagnostics.
+    //
+    DEBUG((EFI_D_INFO, "Signaling BIOS device to collect EFI diagnostics...\n"));
+    WriteBiosDevice(BiosConfigProcessEfiDiagnostics, TRUE);
 
     //
     // BootManagerMenu doesn't contain the correct information when return status is EFI_NOT_FOUND.

--- a/MsvmPkg/Library/DeviceBootManagerLib/DeviceBootManagerLib.inf
+++ b/MsvmPkg/Library/DeviceBootManagerLib/DeviceBootManagerLib.inf
@@ -35,6 +35,7 @@ CONSTRUCTOR                    = DeviceBootManagerConstructor
 
 [LibraryClasses]
   BaseMemoryLib
+  BiosDeviceLib
   DebugLib
   DevicePathLib
   DxeServicesTableLib

--- a/MsvmPkg/MsvmPkgX64.dsc
+++ b/MsvmPkg/MsvmPkgX64.dsc
@@ -383,7 +383,7 @@
 
   #
   # The runtime state of these two Debug PCDs can be modified in the debugger by
-  # modifyting EfiBdDebugPrintGlobalMask and EfiBdDebugPrintComponentMask.
+  # modifying EfiBdDebugPrintGlobalMask and EfiBdDebugPrintComponentMask.
   #
 !ifdef DEBUG_NOISY
   gEfiMdePkgTokenSpaceGuid.PcdDebugPrintErrorLevel|0x804FEF4B

--- a/MsvmPkg/PlatformDeviceStateHelper/PlatformDeviceStateHelper.inf
+++ b/MsvmPkg/PlatformDeviceStateHelper/PlatformDeviceStateHelper.inf
@@ -18,10 +18,13 @@ ENTRY_POINT         = PlatformDeviceStateHelperInit
   PlatformDeviceStateHelper.c
 
 [LibraryClasses]
+  AdvancedLoggerLib
   BaseLib
+  BiosDeviceLib
   CrashLib
   DebugLib
   DeviceStateLib
+  HobLib
   IsolationLib
   MemoryAllocationLib
   UefiDriverEntryPoint
@@ -32,9 +35,11 @@ ENTRY_POINT         = PlatformDeviceStateHelperInit
   MdePkg/MdePkg.dec
   MdeModulePkg/MdeModulePkg.dec
   MsCorePkg/MsCorePkg.dec
+  AdvLoggerPkg/AdvLoggerPkg.dec
 
 [Guids]
-  gEfiGlobalVariableGuid                                  ## CONSUMES
+  gAdvancedLoggerHobGuid                                  ## CONSUMES
+  gEfiGlobalVariableGuid                                  ## CONSUMES   
 
 [Depex]
   gEfiVariableArchProtocolGuid AND

--- a/MsvmPkg/PlatformPei/PlatformPei.inf
+++ b/MsvmPkg/PlatformPei/PlatformPei.inf
@@ -39,12 +39,14 @@
     NetworkPkg/NetworkPkg.dec
     SecurityPkg/SecurityPkg.dec
     UefiCpuPkg/UefiCpuPkg.dec
+    AdvLoggerPkg/AdvLoggerPkg.dec
     MsvmPkg/MsvmPkg.dec
 
 [Packages.AARCH64]
     ArmPkg/ArmPkg.dec
 
 [LibraryClasses]
+    AdvancedLoggerLib
     CrashLib
     DeviceStateLib
     DebugLib
@@ -66,10 +68,11 @@
     ArmLib
 
 [Guids]
+    gAdvancedLoggerHobGuid
+    gDxeMemoryProtectionSettingsGuid
     gEfiMemoryTypeInformationGuid
     gMsvmDebuggerEnabledGuid
     gMsvmDebuggerKdnetBinaryGuid
-    gDxeMemoryProtectionSettingsGuid
 
 [Guids.AARCH64]
     gArmTokenSpaceGuid


### PR DESCRIPTION
This change sends the advanced logger's buffer's GPA to the host via the BiosDevice

----
#### AI description  (iteration 1)
#### PR Classification
New feature

#### PR Summary
This pull request adds functionality to send the advanced logger in-memory buffer address to the BiosDevice, improving diagnostic capabilities.
- `MsvmPkg/PlatformPei/Platform.c`: Added code to retrieve and send the advanced logger buffer address to the BIOS.
- `MsvmPkg/Include/BiosInterface.h`: Introduced a new BIOS configuration parameter for the advanced logger buffer GPA.
- `MsvmPkg/PlatformPei/PlatformPei.inf`: Included `AdvLoggerPkg` and `AdvancedLoggerLib` in the package and library dependencies. <!-- GitOpsUserAgent=GitOps.Apps.Server.pullrequestcopilot -->

Related work items: #53663652