### PR TITLE
Merged PR 12790460: Promote boot failure logs to WARN

### DIFF
--- a/MsvmPkg/Library/DeviceBootManagerLib/DeviceBootManagerLib.c
+++ b/MsvmPkg/Library/DeviceBootManagerLib/DeviceBootManagerLib.c
@@ -619,17 +619,17 @@ DeviceBootManagerUnableToBoot (
 
     // Log the boot order if there is any
     if (BootOrderSize == 0) {
-        DEBUG((DEBUG_INFO, "Boot order is empty\n"));
+        DEBUG((DEBUG_WARN, "Boot order is empty\n"));
     } else {
         BootOptions = EfiBootManagerGetLoadOptions (&BootOptionCount, LoadOptionTypeBoot);
-        DEBUG((DEBUG_INFO, "Boot order : \n"));
+        DEBUG((DEBUG_WARN, "Boot order : \n"));
         for (Index = 0; Index < BootOrderSize / sizeof (UINT16); Index++) {
             DevicePathString = ConvertDevicePathToText (
                         BootOptions[Index].FilePath,
                         FALSE,
                         FALSE
                         );
-            DEBUG((DEBUG_INFO, "Boot%04x Description: %s. Filepath: %s \n", BootOptions[Index].OptionNumber, BootOptions[Index].Description, DevicePathString));
+            DEBUG((DEBUG_WARN, "Boot%04x Description: %s. Filepath: %s \n", BootOptions[Index].OptionNumber, BootOptions[Index].Description, DevicePathString));
             if (DevicePathString != NULL) {
                 FreePool (DevicePathString);
             }
@@ -639,14 +639,14 @@ DeviceBootManagerUnableToBoot (
     if (AttemptDefaultBoot) {
         EfiBootManagerConnectAll();
 
-        //Attempt HDD
+        // Attempt HDD
         if (PcdGetBool(PcdIsVmbfsBoot)) {
             Status = SelectAndBootDevice(&gEfiSimpleFileSystemProtocolGuid, FilterNoUSB);
-            DEBUG((DEBUG_INFO, "Attempted to boot from HDD with FilterNoUSB, SelectAndBootDevice returned %r\n", Status));
+            DEBUG((DEBUG_WARN, "Attempted to boot from HDD with FilterNoUSB, SelectAndBootDevice returned %r\n", Status));
         }
         else {
             Status = SelectAndBootDevice(&gEfiSimpleFileSystemProtocolGuid, FilterOnlyMedia);
-            DEBUG((DEBUG_INFO, "Attempted to boot from HDD with FilterOnlyMedia, SelectAndBootDevice returned %r\n", Status));
+            DEBUG((DEBUG_WARN, "Attempted to boot from HDD with FilterOnlyMedia, SelectAndBootDevice returned %r\n", Status));
         }
 
         if(PcdGetBool(PcdDefaultBootAttemptPxe)) {
@@ -663,12 +663,12 @@ DeviceBootManagerUnableToBoot (
             {
                 //IPv6
                 Status = SelectAndBootDevice(&gEfiLoadFileProtocolGuid, FilterOnlyIPv6);
-                DEBUG((DEBUG_INFO, "Attempted to PXE boot from IPv6, SelectAndBootDevice returned %r\n", Status));
+                DEBUG((DEBUG_WARN, "Attempted to PXE boot from IPv6, SelectAndBootDevice returned %r\n", Status));
             }
             else {
                 //IPv4
                 Status = SelectAndBootDevice(&gEfiLoadFileProtocolGuid, FilterOnlyIPv4);
-                DEBUG((DEBUG_INFO, "Attempted to PXE boot from IPv4, SelectAndBootDevice returned %r\n", Status));
+                DEBUG((DEBUG_WARN, "Attempted to PXE boot from IPv4, SelectAndBootDevice returned %r\n", Status));
             }
 
             //Reset to native resolution


### PR DESCRIPTION
Changes the boot failure logs to WARN instead of INFO. This allows them to show up in the Efi Diagnostics from the host by default

----
#### AI description  (iteration 1)
#### PR Classification
Log level adjustment to improve visibility of boot failure events.

#### PR Summary
This pull request promotes boot failure logs from `DEBUG_INFO` to `DEBUG_WARN` to enhance the visibility of boot-related issues, aligning with the work item to log and upload boot-related data to Kusto.
- `DeviceBootManagerLib.c`: Changed log level from `DEBUG_INFO` to `DEBUG_WARN` for messages related to boot order, HDD boot attempts, and PXE boot attempts. <!-- GitOpsUserAgent=GitOps.Apps.Server.pullrequestcopilot -->

Related work items: #46153984