### PR TITLE
Merged PR 12781108: Use SYSTEM_RESET2 with HV_ARM64_SYSTEM_RESET2_FIRMWARE_CRASH when ResetAfterCrash

### DIFF
--- a/MsvmPkg/Include/Hv/HvGuest.h
+++ b/MsvmPkg/Include/Hv/HvGuest.h
@@ -45,6 +45,11 @@ typedef UINT64 HV_GPA_PAGE_NUMBER, *PHV_GPA_PAGE_NUMBER;
 //
 #define HV_ARM64_ENABLE_SRE             2
 
+//
+// Vendor-specific reset types
+//
+#define HV_ARM64_SYSTEM_RESET2_FIRMWARE_CRASH 0x80000001
+
 #elif defined(MDE_CPU_X64)
 
 #define HV_X64_PAGE_SIZE                4096

--- a/MsvmPkg/Library/CrashLib/AArch64/Crash.c
+++ b/MsvmPkg/Library/CrashLib/AArch64/Crash.c
@@ -27,25 +27,17 @@ ResetAfterCrash(
 {
     DEBUG((DEBUG_INFO, "Initiating crash reset...\n"));
 
-    // Is SYSTEM_RESET2 supported?
+    // The Microsoft hypervisor does not advertise support for SystemReset2
+    // Directly call PSCI without checking for feature support.
     UINTN advancedReset = ARM_SMC_ID_PSCI_SYSTEM_RESET2_AARCH64;
-    UINTN psciReturn = ArmCallSmc1(ARM_SMC_ID_PSCI_FEATURES, &advancedReset, NULL, NULL);
-    if (psciReturn == ARM_SMC_PSCI_RET_SUCCESS)
-    {
-        UINTN resetType = 0x80000002;   // TODO: Proposed machine check reset
-        UINTN cookie = ErrorCode;
+    UINTN resetType = HV_ARM64_SYSTEM_RESET2_FIRMWARE_CRASH;
+    UINTN cookie = ErrorCode;
 
-        // Send PSCI SYSTEM_RESET2 command.  This should not return on success.
-        DEBUG ((DEBUG_INFO, "Issuing PSCI_SYSTEM_RESET2...\n"));
-        psciReturn = ArmCallSmc0(advancedReset, &resetType, &cookie, NULL);
+    // Send PSCI SYSTEM_RESET2 command.  This should not return on success.
+    DEBUG ((DEBUG_INFO, "Issuing PSCI_SYSTEM_RESET2...\n"));
+    UINTN psciReturn = ArmCallSmc0(advancedReset, &resetType, &cookie, NULL);
 
-        DEBUG ((DEBUG_INFO, "PSCI_SYSTEM_RESET2 not successful. %x\n", psciReturn));
-    }
-    else
-    {
-        DEBUG ((DEBUG_INFO, "PSCI_SYSTEM_RESET2 not supported by platform. %x\n", psciReturn));
-    }
-
+    DEBUG ((DEBUG_INFO, "PSCI_SYSTEM_RESET2 not successful. %x\n", psciReturn));
     DEBUG ((DEBUG_INFO, "Issuing PSCI_SYSTEM_RESET...\n"));
     ArmCallSmc0(ARM_SMC_ID_PSCI_SYSTEM_RESET, NULL, NULL, NULL);
 }


### PR DESCRIPTION
#### AI description  (iteration 1)
#### PR Classification
Code modification to improve system reset handling after a crash.

#### PR Summary
This pull request updates the crash reset mechanism to use `SYSTEM_RESET2` with `HV_ARM64_SYSTEM_RESET2_FIRMWARE_CRASH`.
- `MsvmPkg/Library/CrashLib/AArch64/Crash.c`: Modified to directly call PSCI for `SYSTEM_RESET2` without checking for feature support and updated reset type to `HV_ARM64_SYSTEM_RESET2_FIRMWARE_CRASH`.
- `MsvmPkg/Include/Hv/HvGuest.h`: Added definition for `HV_ARM64_SYSTEM_RESET2_FIRMWARE_CRASH`. <!-- GitOpsUserAgent=GitOps.Apps.Server.pullrequestcopilot -->

Related work items: #57509509