### PR TITLE
Merged PR 12937822: Ring efi diagnostics doorbell when NVRAM hits ebs

### DIFF
--- a/MsvmPkg/Library/MsPlatBdsLib/BdsPlatform.c
+++ b/MsvmPkg/Library/MsPlatBdsLib/BdsPlatform.c
@@ -12,6 +12,8 @@
 #include <Library/UefiRuntimeServicesTableLib.h>
 #include <Library/BaseLib.h>
 #include <Library/BootEventLogLib.h>
+#include <Library/BiosDeviceLib.h>
+#include <BiosInterface.h>
 
 static EFI_EVENT    mExitBootServicesEvent = NULL;
 
@@ -45,6 +47,12 @@ Returns:
     DEBUG((DEBUG_INFO, "[HVBE] Updating boot event: BootDeviceOsLoaded, EFI_SUCCESS\n"));
     BootDeviceEventFlushLog();
     DEBUG((DEBUG_INFO, "[HVBE] Flushing boot event log\n"));
+    
+    //
+    // Tell the host to collect EFI diagnostics.
+    //
+    DEBUG((DEBUG_INFO, "Signaling BIOS device to collect EFI diagnostics...\n"));
+    WriteBiosDevice(BiosConfigProcessEfiDiagnostics, TRUE);
 }
 
 

--- a/MsvmPkg/Library/MsPlatBdsLib/MsPlatBdsLib.inf
+++ b/MsvmPkg/Library/MsPlatBdsLib/MsPlatBdsLib.inf
@@ -31,6 +31,7 @@
 
 [LibraryClasses]
   BaseLib
+  BiosDeviceLib
   MemoryAllocationLib
   UefiBootServicesTableLib
   DebugLib


### PR DESCRIPTION
Ring the doorbell to process EFI diagnostics when NVRAM hits EBS. This is done after issuing the signal runtime command.

As such, the host will not need to manually execute its processing function in the NVRAM signal runtime code path anymore.

----
#### AI description  (iteration 1)
#### PR Classification
This PR introduces a new feature to signal EFI diagnostics when a specific NVRAM event occurs, aligning with the MsvmPkg Diagnostic Improvements work item.

#### PR Summary
The changes enhance diagnostic capabilities by ringing the EFI diagnostics doorbell immediately after issuing the NVRAM command.
- `MsvmPkg/VariableDxe/NvramVariableDxe.c`: Added a debug log and a call to `WriteBiosDevice(BiosConfigProcessEfiDiagnostics, TRUE)` to trigger EFI diagnostics, and included `<Uefi/UefiBaseType.h>` to support the change. <!-- GitOpsUserAgent=GitOps.Apps.Server.pullrequestcopilot -->

Related work items: #53663652