### PR TITLE
[WIP] Remove macoma arm exception handlers

### DIFF
--- a/MsvmPkg/Sec/AArch64/SecEntry.masm
+++ b/MsvmPkg/Sec/AArch64/SecEntry.masm
@@ -15,17 +15,11 @@
 StartupAddr
     DCQ     SecStartupWithStack
 
-TransitionIdtAddr
-    DCQ     TransitionIdt
-
 _ModuleEntryPoint PROC
 
     // Loader sets register state that become inputs to this function
     //  x0 - Firmware Volume Base Address
     //  x1 - Stack Base Address
-
-    ldr     x4, TransitionIdtAddr       // setup simple, default exception handlers
-    msr     vbar_el1, x4                // as workaround to hang issue on macoma
 
     // bl SerialWriteBanner             // print banner to COM2
 
@@ -140,119 +134,5 @@ SerialWriteBanner PROC
     ret
 
 SerialWriteBanner ENDP
-
-//
-// Simple Exception handlers as workaround for hang issue on macoma
-//
-
-    AREA    |.vectors|,ALIGN=3,CODE
-
-    ALIGN 2048
-
-TransitionIdt
-
-// Current EL with SP_EL0, Synchronous
-TransitionIdtKernelSp0ExceptionHandler
-    b   TransitionIdtKernelSp0ExceptionHandler
-
-    ALIGN 128
-
-// Current EL with SP_EL0, IRQ/vIRQ
-TransitionIdtKernelSp0InterruptHandler
-    b   TransitionIdtKernelSp0InterruptHandler
-
-    ALIGN 128
-
-// Current EL with SP_EL0, FIQ/vFIQ
-TransitionIdtKernelSp0FiqHandler
-    b TransitionIdtKernelSp0FiqHandler
-
-    ALIGN 128
-
-// Current EL with SP_EL0, SError/VSError
-TransitionIdtKernelSp0SystemErrorHandler
-    b   TransitionIdtKernelSp0SystemErrorHandler
-
-    ALIGN 128
-
-// Current EL with SP_ELx, Synchronous
-TransitionIdtKernelExceptionHandler
-    b   TransitionIdtKernelExceptionHandler
-
-    ALIGN 128
-
-// Current EL with SP_ELx, IRQ/vIRQ
-TransitionIdtKernelInterruptHandler
-    b   TransitionIdtKernelInterruptHandler
-
-    ALIGN 128
-
-// Current EL with SP_ELx, FIQ/vFIQ
-TransitionIdtKernelFiqHandler
-    b   TransitionIdtKernelFiqHandler
-
-    ALIGN 128
-
-// Current EL with SP_ELx, SError/VSError
-TransitionIdtKernelSystemErrorHandler
-    b   TransitionIdtKernelSystemErrorHandler
-
-    ALIGN 128
-
-// Lower EL using AArch64, Synchronous
-TransitionIdtUserExceptionHandler
-    b   TransitionIdtUserExceptionHandler// We're not implementing EL0
-
-    ALIGN 128
-
-// Lower EL using AArch64, IRQ/vIRQ
-TransitionIdtUserInterruptHandler
-    b   TransitionIdtUserInterruptHandler// We're not implementing EL0
-
-    ALIGN 128
-
-// Lower EL using AArch64, FIQ/vFIQ
-TransitionIdtUserFiqHandler
-    b   TransitionIdtUserFiqHandler // We're not implementing EL0
-
-    ALIGN 128
-
-// Lower EL using AArch64, SError/VSError
-TransitionIdtUserSystemErrorHandler
-    b   TransitionIdtUserSystemErrorHandler // We're not implementing EL0
-
-    ALIGN 128
-
-// Lower EL using AArch32, Synchronous
-TransitionIdtUser32ExceptionHandler
-    b   TransitionIdtUser32ExceptionHandler
-
-    ALIGN 128
-
-// Lower EL using AArch32, IRQ/vIRQ
-TransitionIdtUser32InterruptHandler
-    b   TransitionIdtUser32InterruptHandler
-
-    ALIGN 128
-
-// Lower EL using AArch32, FIQ/vFIQ
-TransitionIdtUser32FiqHandler
-    b   TransitionIdtUser32FiqHandler
-
-    ALIGN 128
-
-// Lower EL using AArch32, SError/VSError
-TransitionIdtUser32SystemErrorHandler
-    b   TransitionIdtUser32SystemErrorHandler
-
-    ALIGN 128
-
-TransitionIdtEnd
-
-// Assert that the vector table has the right size
-    ASSERT TransitionIdtEnd - TransitionIdt == 2048
-
-TransitionIdtUnexpectedException
-    b   TransitionIdtUnexpectedException
 
     END


### PR DESCRIPTION
Remove macoma arm exception handler code. We do not use this platform at all today. This _might_ also address a rare arm hang with OpenHCL configs