### PR TITLE
Add Pcd to filter out additional Nvme namespaces

### DIFF
--- a/MsvmPkg/MsvmPkg.dec
+++ b/MsvmPkg/MsvmPkg.dec
@@ -291,6 +291,7 @@
   gMsvmPkgTokenSpaceGuid.PcdHostEmulatorsWhenHardwareIsolated|FALSE|BOOLEAN|0x6064
   gMsvmPkgTokenSpaceGuid.PcdTpmLocalityRegsEnabled|FALSE|BOOLEAN|0x6065
   gMsvmPkgTokenSpaceGuid.PcdMtrrsInitializedAtLoad|FALSE|BOOLEAN|0x6067
+  gMsvmPkgTokenSpaceGuid.PcdNvmeNamespaceFilter|FALSE|BOOLEAN|0x6068
 
   # UEFI_CONFIG_PROCESSOR_INFORMATION
   gMsvmPkgTokenSpaceGuid.PcdProcessorCount|0x0|UINT32|0x6032

--- a/MsvmPkg/NvmExpressDxe/NvmExpress.h
+++ b/MsvmPkg/NvmExpressDxe/NvmExpress.h
@@ -126,6 +126,9 @@ extern EFI_DRIVER_SUPPORTED_EFI_VERSION_PROTOCOL  gNvmExpressDriverSupportedEfiV
 
 #define NVME_CONTROLLER_ID  0
 
+// MS_HYP_CHANGE: FIRST_NAMESPACE_ID for filtering
+#define NVME_FIRST_NSID  0x00000001
+
 //
 // Time out value for Nvme transaction execution
 //

--- a/MsvmPkg/NvmExpressDxe/NvmExpressDxe.inf
+++ b/MsvmPkg/NvmExpressDxe/NvmExpressDxe.inf
@@ -90,6 +90,7 @@
   ## MU_CHANGE [END]
   gMsvmPkgTokenSpaceGuid.PcdIsolationSharedGpaBoundary                ## MS_HYP_CHANGE
   gMsvmPkgTokenSpaceGuid.PcdIsolationSharedGpaCanonicalizationBitmask ## MS_HYP_CHANGE
+  gMsvmPkgTokenSpaceGuid.PcdNvmeNamespaceFilter                       ## MS_HYP_CHANGE
 
 # [Event]
 # EVENT_TYPE_RELATIVE_TIMER ## SOMETIMES_CONSUMES

--- a/MsvmPkg/PlatformPei/Config.c
+++ b/MsvmPkg/PlatformPei/Config.c
@@ -1551,6 +1551,7 @@ Return Value:
             case UefiConfigVpciInstanceFilter:
                 UEFI_CONFIG_VPCI_INSTANCE_FILTER *filter = (UEFI_CONFIG_VPCI_INSTANCE_FILTER*) header;
                 PEI_FAIL_FAST_IF_FAILED(PcdSet64S(PcdVpciInstanceFilterGuidPtr, (UINT64) filter->InstanceGuid));
+                PEI_FAIL_FAST_IF_FAILED(PcdSetBoolS(PcdNvmeNamespaceFilter, TRUE));
                 break;
 
 #if defined(MDE_CPU_X64)

--- a/MsvmPkg/PlatformPei/PlatformPei.inf
+++ b/MsvmPkg/PlatformPei/PlatformPei.inf
@@ -192,6 +192,7 @@
     gMsvmPkgTokenSpaceGuid.PcdHostEmulatorsWhenHardwareIsolated
     gMsvmPkgTokenSpaceGuid.PcdTpmLocalityRegsEnabled
     gMsvmPkgTokenSpaceGuid.PcdMtrrsInitializedAtLoad
+    gMsvmPkgTokenSpaceGuid.PcdNvmeNamespaceFilter
 
 [Pcd.AArch64]
     gMsvmPkgTokenSpaceGuid.PcdSystemMemoryBaseAddress


### PR DESCRIPTION
Tested with OpenVmm, only the first namespace is shown.