### PR TITLE
Merged PR 13533125: Fix section alignment to 4096 instead of 32

### DIFF
--- a/MsvmPkg/MsvmPkgAARCH64.dsc
+++ b/MsvmPkg/MsvmPkgAARCH64.dsc
@@ -43,6 +43,9 @@
 [BuildOptions.common.EDKII.DXE_RUNTIME_DRIVER]
   MSFT:*_*_AARCH64_DLINK_FLAGS = /ALIGN:0x10000
 
+[BuildOptions.common.EDKII.SEC, BuildOptions.common.EDKII.PEIM, BuildOptions.common.EDKII.PEI_CORE]
+  MSFT:*_*_*_DLINK_FLAGS = /ALIGN:4096 /FILEALIGN:4096
+
 ################################################################################
 #
 # SKU Identification section - list of all SKU IDs supported by this Platform.

--- a/MsvmPkg/MsvmPkgX64.dsc
+++ b/MsvmPkg/MsvmPkgX64.dsc
@@ -39,6 +39,16 @@
   *_*_X64_GENFW_FLAGS = --keepexceptiontable
   DEBUG_*_*_CC_FLAGS = -D DEBUG_PLATFORM
 
+  # Generate PDBs on release builds with full debugging, with linker and CC flags
+  MSFT:*_*_*_DLINK_FLAGS = /DEBUG:FULL /PDBALTPATH:$(MODULE_NAME).pdb
+  MSFT:*_*_*_CC_FLAGS = /Zi
+
+[BuildOptions.common.EDKII.DXE_CORE]
+  MSFT:*_*_*_DLINK_FLAGS = /FILEALIGN:4096
+
+[BuildOptions.common.EDKII.SEC, BuildOptions.common.EDKII.PEIM, BuildOptions.common.EDKII.PEI_CORE]
+  MSFT:*_*_*_DLINK_FLAGS = /ALIGN:4096 /FILEALIGN:4096
+
 ################################################################################
 #
 # SKU Identification section - list of all SKU IDs supported by this Platform.
@@ -944,14 +954,3 @@
   PrmPkg/Samples/PrmSampleHardwareAccessModule/PrmSampleHardwareAccessModule.inf
   PrmPkg/Samples/PrmSampleContextBufferModule/PrmSampleContextBufferModule.inf
 !endif
-
-[BuildOptions]
-  # Generate PDBs on release builds with full debugging, with linker and CC flags
-  MSFT:*_*_*_DLINK_FLAGS = /DEBUG:FULL /PDBALTPATH:$(MODULE_NAME).pdb
-  MSFT:*_*_*_CC_FLAGS = /Zi
-
-[BuildOptions.common.EDKII.DXE_CORE]
-  MSFT:*_*_*_DLINK_FLAGS = /FILEALIGN:4096
-
-[BuildOptions.common.EDKII.SEC, BuildOptions.common.EDKII.PEIM, BuildOptions.common.EDKII.PEI_CORE]
-  MSFT:*_*_*_DLINK_FLAGS = /ALIGN:32 /FILEALIGN:32


### PR DESCRIPTION
This PR changes our section alignment to 4096 instead of 32. It also moves the build flags in x64 .dsc to the top. This helps avoid a `DoNotMarkWritableSectionsAsExecutable` error caught by binskim.

----
#### AI description  (iteration 1)
#### PR Classification
This pull request fixes a configuration bug by updating section alignment settings to address a security vulnerability.

#### PR Summary
The changes update build configuration files to correct section alignment from 32 to 4096, ensuring compliance with security requirements and addressing critical BA2021 binskim errors.
- `MsvmPkg/MsvmPkgX64.dsc`: Removed the outdated alignment flags (/ALIGN:32 /FILEALIGN:32) and reintroduced proper debug and alignment options set to 4096.
- `MsvmPkg/MsvmPkgAARCH64.dsc`: Added build options for SEC, PEIM, and PEI_CORE with flags updated to /ALIGN:4096 /FILEALIGN:4096. <!-- GitOpsUserAgent=GitOps.Apps.Server.pullrequestcopilot -->

Related work items: #58702511, #58702512, #58702534, #58702536, #58702555, #58702556, #58702583, #58702593, #58702592, #58702591, #58702590, #58702589, #58702588, #58702587, #58702586, #58702585, #58702584, #58702564, #58702563, #58702562, #58702561, #58702560, #58702558, #58702557, #58702554, #58702553, #58702540, #58702539, #58702538, #58702537, #58702535, #58702533, #58702532, #58702531, #58702530, #58702520, #58702519, #58702516, #58702494, #58702492, #58702491, #58702490, #58702487, #58702474