### PR TITLE
Merged PR 13585217: UEFI platform-specific boot log fixes

### DIFF
--- a/MsvmPkg/Library/DeviceBootManagerLib/DeviceBootManagerLib.c
+++ b/MsvmPkg/Library/DeviceBootManagerLib/DeviceBootManagerLib.c
@@ -482,7 +482,7 @@ DeviceBootManagerBeforeConsole (
         }
     }
     else {
-        DEBUG((DEBUG_ERROR, "Handle for Hyper-V keyboard device not found\n"));
+        DEBUG((DEBUG_WARN, "Handle for Hyper-V keyboard device not found\n"));
     }
 
     if (ConsoleOut != NULL) {
@@ -503,7 +503,7 @@ DeviceBootManagerBeforeConsole (
         }
     }
     else {
-        DEBUG((DEBUG_ERROR, "Handle for Hyper-V video device not found\n"));
+        DEBUG((DEBUG_WARN, "Handle for Hyper-V video device not found\n"));
     }
 
     *PlatformConsoles = (BDS_CONSOLE_CONNECT_ENTRY *)&gPlatformConsoles;
@@ -542,7 +542,7 @@ DeviceBootManagerAfterConsole (
                             &HandleBuffer );
 
     for (Index = 0; Index < HandleCount; Index++) {
-        DEBUG((DEBUG_ERROR, "Connecting controller for handle %d \n", Index));
+        DEBUG((DEBUG_INFO, "Connecting controller for handle %d \n", Index));
         gBS->ConnectController(HandleBuffer[Index], NULL, NULL, TRUE);
     }
 

--- a/MsvmPkg/PlatformPei/Platform.c
+++ b/MsvmPkg/PlatformPei/Platform.c
@@ -982,8 +982,12 @@ Return Value:
 
     //
     // Set the boot mode and installs the boot mode tag PPI.
-    //
-    status = PeiServicesSetBootMode(BOOT_WITH_FULL_CONFIGURATION);
+    // For virtualized hosts we assume no configuration changes so that
+    // BDS does not report "THIS BOOT MODE IS UNSUPPORTED" for
+    // BOOT_WITH_FULL_CONFIGURATION. On bare-metal platforms that need
+    // full hardware reconfiguration or memory retraining, consider
+    // setting BOOT_WITH_FULL_CONFIGURATION instead.
+    status = PeiServicesSetBootMode(BOOT_ASSUMING_NO_CONFIGURATION_CHANGES);
     ASSERT_EFI_ERROR(status);
 
     status = PeiServicesInstallPpi(MsvmBootModePpiDescriptor);


### PR DESCRIPTION
This PR does the following:
- Changes boot mode configuration in PEI to `BOOT_ASSUMING_NO_CONFIGURATION_CHANGES`
    - This avoids the "THIS BOOT MODE IS UNSUPPORTED" error message in EfiDiagnostics

- Demotes logs about missing keyboard and mouse to WARN instead of ERROR

- Demotes a connection controller log to INFO

Tested with OpenVMM like so:
```
 cargo run -- --uefi --uefi-firmware /mnt/d/projects/uefi/ACTIVE/Build/MsvmX64/DEBUG_VS2022/FV/MSVM.fd
```

New output attached with these changes:
[uefilog-changes.txt](https://microsoft.visualstudio.com/8d47e068-03c8-4cdc-aa9b-fc6929290322/_apis/git/repositories/1ad2e189-11bd-479f-8f25-a739cc641dfa/pullRequests/13585217/attachments/uefilog-changes.txt)

Related work items: #58949684