### PR TITLE
Merged PR 13634151: VPCI Changes for supporting AziHsm Device

### DIFF
--- a/MsvmPkg/VpcivscDxe/VpcivscDxe.h
+++ b/MsvmPkg/VpcivscDxe/VpcivscDxe.h
@@ -29,7 +29,6 @@ typedef struct _VPCI_BAR_INFORMATION
     UINT64 MappedAddress; // The address where this bar was allocated and mapped
     UINT64 Size; // The size of this bar
     BOOLEAN Is64Bit; // The type of bar, 32 bit or 64 bit
-    UINT8 BarIndex; // The index into the RawBars array for where this bar starts
 } VPCI_BAR_INFORMATION, *PVPCI_BAR_INFORMATION;
 
 // Context structure for each VPCI device
@@ -50,6 +49,8 @@ typedef struct _VPCI_DEVICE_CONTEXT
     VPCIVSC_CONTEXT *VpcivscContext;
     PCI_SLOT_NUMBER Slot;
 
+    // Pointer to the original device description from the VSP
+    CONST VPCI_DEVICE_DESCRIPTION *DeviceDescription;
 } VPCI_DEVICE_CONTEXT, *PVPCI_DEVICE_CONTEXT;
 
 #define VPCI_DEVICE_CONTEXT_SIGNATURE SIGNATURE_32('v', 'p', 'c', 'd')
@@ -74,9 +75,15 @@ typedef struct _VPCIVSC_CONTEXT
     VPCI_DEVICE_DESCRIPTION *Devices;
     UINT32 DeviceCount;
 
-    // We only really care about NVMe devices.
+    // We only really care about NVMe devices + AziHsm Device
+    // AziHsm Devices have Base/Sub Class different From Nvme
     VPCI_DEVICE_CONTEXT *NvmeDevices;
     UINT32 NvmeDeviceCount;
+
+    // Azure Integrated HSM devices for config space access only.
+    VPCI_DEVICE_CONTEXT *AziHsmDevices;
+    UINT32 AziHsmDeviceCount;
+    
 } VPCIVSC_CONTEXT, *PVPCIVSC_CONTEXT;
 
 #define VPCIVSC_DRIVER_VERSION 0x1
@@ -139,6 +146,12 @@ VpcivscComponentNameGetControllerName(
     IN  EFI_HANDLE ChildHandle OPTIONAL,
     IN  CHAR8 *Language,
     OUT CHAR16 **ControllerName
+    );
+
+    // Device detection functions
+BOOLEAN
+IsAziHsmDevice(
+    CONST PVPCI_DEVICE_DESCRIPTION Device
     );
 
 // EMCL functions, VSC protocol functions


### PR DESCRIPTION
This PR adds support for the AziHsm device.

- Add support for recognizing the AziHsm Controllers.
- Bug Fixes in VpcivscPciIo file because the MMIO/Config access were not correctly implemented for some access patterns.
- These changes are verified with AziHsm UEFI driver.

----
#### AI description  (iteration 1)
#### PR Classification
This pull request introduces a new feature by adding support for the AziHsm device in the VPCI driver for the UEFI branch.

#### PR Summary
The changes extend the VPCI driver to detect, allocate, and manage AziHsm devices in parallel with NVMe devices. The updates improve device context management, logging, and PCI configuration to correctly handle the new device type.
- **`MsvmPkg/VpcivscDxe/VpcivscDxe.c`**: Added logic to detect and count AziHsm devices, allocate and initialize their contexts, and incorporate them into cleanup and logging routines.
- **`MsvmPkg/VpcivscDxe/VpcivscDxe.h`**: Updated the VPCI context structure with new fields for AziHsm devices and added the function prototype for device detection.
- **`MsvmPkg/VpcivscDxe/VpcivscPciIo.c`**: Modified configuration and memory access routines to use actual device descriptor values for vendor, device, and class codes, ensuring proper support for both NVMe and AziHsm devices. <!-- GitOpsUserAgent=GitOps.Apps.Server.pullrequestcopilot -->

Related work items: #59031935