### PR TITLE
ci: automatically create a release on every merged PR

### DIFF
--- a/.github/workflows/Platform-Build.yml
+++ b/.github/workflows/Platform-Build.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches:
       - '*'
+  workflow_dispatch:
+
+permissions:
+  contents: write
 
 jobs:
   build:
@@ -131,8 +135,40 @@ jobs:
       - name: Upload Build Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{matrix.target}}-${{matrix.arch}}-${{matrix.tools}}artifacts
+          name: ${{matrix.target}}-${{matrix.arch}}-${{matrix.tools}}-artifacts
           path: |
             Build/Msvm${{matrix.arch}}/${{matrix.target}}_${{matrix.tools}}/FV/MSVM.fd
             Build/Msvm${{matrix.arch}}/${{matrix.target}}_${{matrix.tools}}/MAP/
             Build/Msvm${{matrix.arch}}/${{matrix.target}}_${{matrix.tools}}/PDB/
+
+  release:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Zip artifacts for release
+        run: |
+          mkdir -p release
+          cd artifacts
+          for dir in */; do
+            name="${dir%/}"
+            (cd "$name" && zip -r "../../release/${name}.zip" .)
+          done
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "v26.0.${{ github.run_number }}" \
+            --repo "${{ github.repository }}" \
+            --target "${{ github.sha }}" \
+            --generate-notes \
+            release/*.zip

--- a/.github/workflows/Platform-Build.yml
+++ b/.github/workflows/Platform-Build.yml
@@ -12,6 +12,11 @@ on:
 permissions:
   contents: write
 
+# Bump this when releasing a new major/minor version. The patch number
+# auto-increments from the latest existing GitHub release with this prefix.
+env:
+  BASE_VERSION: "26.0"
+
 jobs:
   build:
     runs-on: windows-latest
@@ -167,7 +172,12 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create "v26.0.${{ github.run_number }}" \
+          # Find the highest patch number for this major.minor version
+          # and increment by one. Resets to 0 when BASE_VERSION is bumped.
+          PATCH=$(gh release list --limit 1000 --json tagName \
+            --jq '[.[] | .tagName | select(startswith("v'"${{ env.BASE_VERSION }}"'.")) | ltrimstr("v'"${{ env.BASE_VERSION }}"'.") | tonumber] | max // -1 | . + 1')
+          TAG="v${{ env.BASE_VERSION }}.${PATCH}"
+          gh release create "$TAG" \
             --repo "${{ github.repository }}" \
             --target "${{ github.sha }}" \
             --generate-notes \

--- a/.github/workflows/Platform-Build.yml
+++ b/.github/workflows/Platform-Build.yml
@@ -9,9 +9,6 @@ on:
       - '*'
   workflow_dispatch:
 
-permissions:
-  contents: write
-
 # Bump this when releasing a new major/minor version. The patch number
 # auto-increments from the latest existing GitHub release with this prefix.
 env:
@@ -33,11 +30,11 @@ jobs:
     steps:
       # Checkout the repository
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Set up Python 3.12
       - name: Set up Python 3.12
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: '3.12'
 
@@ -150,9 +147,14 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: [build]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    concurrency:
+      group: release
+      cancel-in-progress: false
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Download all artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/Platform-Build.yml
+++ b/.github/workflows/Platform-Build.yml
@@ -161,13 +161,13 @@ jobs:
         with:
           path: artifacts
 
-      - name: Zip artifacts for release
+      - name: Package artifacts for release
         run: |
           mkdir -p release
           cd artifacts
           for dir in */; do
             name="${dir%/}"
-            (cd "$name" && zip -r "../../release/${name}.zip" .)
+            tar -czf "../../release/${name}.tar.gz" -C "$name" .
           done
 
       - name: Create GitHub Release
@@ -183,4 +183,4 @@ jobs:
             --repo "${{ github.repository }}" \
             --target "${{ github.sha }}" \
             --generate-notes \
-            release/*.zip
+            release/*.tar.gz


### PR DESCRIPTION
Rather than doing this manually, have github actions do it. Publish artifacts for all build flavors, and change artifacts to be .tar.gz instead of .zip files. 

This is a breaking change and will require changes in consumers (openvmm) to pickup the next release. 