### PR TITLE
ci: fix release step 

### DIFF
--- a/.github/workflows/Platform-Build.yml
+++ b/.github/workflows/Platform-Build.yml
@@ -9,10 +9,13 @@ on:
       - '*'
   workflow_dispatch:
 
-# Bump this when releasing a new major/minor version. The patch number
-# auto-increments from the latest existing GitHub release with this prefix.
 env:
+  # Bump this when releasing a new major/minor version. The patch number
+  # auto-increments from the latest existing GitHub release with this prefix.
   BASE_VERSION: "26.0"
+  # Number of expected build artifacts (2 targets × 2 archs × 2 tools, minus
+  # 2 excluded AARCH64+VS2022 combos = 6). Update if you change the build matrix.
+  EXPECTED_ARTIFACT_COUNT: "6"
 
 jobs:
   build:
@@ -55,10 +58,10 @@ jobs:
           Write-Host "Checking Visual Studio installation path..."
           $vsPath = &"C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products * -property installationPath
           Write-Host "VS Path: $vsPath"
-          
+
           $vsInstaller = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vs_installer.exe"
           Write-Host "Installing Visual Studio components..."
-          
+
           $installResult = & $vsInstaller modify `
             --installPath $vsPath `
             --add Microsoft.VisualStudio.Component.VC.CoreBuildTools `
@@ -69,12 +72,12 @@ jobs:
             --add Microsoft.VisualStudio.Component.VC.Llvm.Clang `
             --add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Llvm.Clang `
             --quiet --wait
-          
+
           Write-Host "Installation completed with exit code: $LASTEXITCODE"
           if ($LASTEXITCODE -ne 0) {
             throw "Visual Studio component installation failed with exit code: $LASTEXITCODE"
           }
-          
+
           Write-Host "Waiting for VS installer to finalize changes..."
           Start-Sleep -Seconds 10
 
@@ -86,21 +89,21 @@ jobs:
           if (-not $vsPath) { throw "Visual Studio is not installed." }
 
           Write-Host "Verifying required build tools are available..."
-          
+
           # Check for VC++ build tools
           $vcToolsPath = Join-Path $vsPath "VC\Tools\MSVC"
           if (-not (Test-Path $vcToolsPath)) {
             throw "VC++ tools directory not found at: $vcToolsPath"
           }
           Write-Host "✓ VC++ build tools found"
-          
+
           # Check for Windows SDK
           $windowsSdkPath = "${env:ProgramFiles(x86)}\Windows Kits\10"
           if (-not (Test-Path $windowsSdkPath)) {
             throw "Windows SDK not found at: $windowsSdkPath"
           }
           Write-Host "✓ Windows SDK found"
-          
+
           # Check for ARM64 tools if they exist
           $armToolsPath = Join-Path $vcToolsPath "*\bin\Hostx64\arm64"
           if (Get-ChildItem $armToolsPath -ErrorAction SilentlyContinue) {
@@ -167,8 +170,13 @@ jobs:
           cd artifacts
           for dir in */; do
             name="${dir%/}"
-            tar -czf "../../release/${name}.tar.gz" -C "$name" .
+            tar -czf "../release/${name}.tar.gz" -C "$name" .
           done
+          COUNT=$(ls ../release/*.tar.gz | wc -l)
+          if [ "$COUNT" -ne "${{ env.EXPECTED_ARTIFACT_COUNT }}" ]; then
+            echo "::error::Expected ${{ env.EXPECTED_ARTIFACT_COUNT }} release artifacts but found $COUNT"
+            exit 1
+          fi
 
       - name: Create GitHub Release
         env:
@@ -176,7 +184,7 @@ jobs:
         run: |
           # Find the highest patch number for this major.minor version
           # and increment by one. Resets to 0 when BASE_VERSION is bumped.
-          PATCH=$(gh release list --limit 1000 --json tagName \
+          PATCH=$(gh release list --repo "${{ github.repository }}" --limit 1000 --json tagName \
             --jq '[.[] | .tagName | select(startswith("v'"${{ env.BASE_VERSION }}"'.")) | ltrimstr("v'"${{ env.BASE_VERSION }}"'.") | tonumber] | max // -1 | . + 1')
           TAG="v${{ env.BASE_VERSION }}.${PATCH}"
           gh release create "$TAG" \

--- a/.github/workflows/Platform-Build.yml
+++ b/.github/workflows/Platform-Build.yml
@@ -13,9 +13,6 @@ env:
   # Bump this when releasing a new major/minor version. The patch number
   # auto-increments from the latest existing GitHub release with this prefix.
   BASE_VERSION: "26.0"
-  # Number of expected build artifacts (2 targets × 2 archs × 2 tools, minus
-  # 2 excluded AARCH64+VS2022 combos = 6). Update if you change the build matrix.
-  EXPECTED_ARTIFACT_COUNT: "6"
 
 jobs:
   build:
@@ -172,11 +169,6 @@ jobs:
             name="${dir%/}"
             tar -czf "../release/${name}.tar.gz" -C "$name" .
           done
-          COUNT=$(ls ../release/*.tar.gz | wc -l)
-          if [ "$COUNT" -ne "${{ env.EXPECTED_ARTIFACT_COUNT }}" ]; then
-            echo "::error::Expected ${{ env.EXPECTED_ARTIFACT_COUNT }} release artifacts but found $COUNT"
-            exit 1
-          fi
 
       - name: Create GitHub Release
         env:


### PR DESCRIPTION
Path traversal was incorrect. Add an additional small fix to always specify the repo in gh release list.