### PR TITLE
Fast forward with closed source changes and reconcile NvmExpressDxe divergence

### DIFF
--- a/MsvmPkg/EfiHvDxe/EfiHv.c
+++ b/MsvmPkg/EfiHvDxe/EfiHv.c
@@ -1154,6 +1154,12 @@ EfiHvpModifySparseGpaPageHostVisibility(
         *PageCountProcessed = 0;
     }
 
+    if (PageCount == 0)
+    {
+        DEBUG((DEBUG_ERROR, "%a: 0 page count\n", __func__));
+        return EFI_INVALID_PARAMETER;
+    }
+
     paravisorPresent = IsParavisorPresent();
 
 #if defined(MDE_CPU_X64)
@@ -1517,8 +1523,8 @@ EfiHvMakeAddressRangeHostVisible(
 VOID
 EFIAPI
 EfiHvMakeAddressRangeNotHostVisible(
-    IN  EFI_HV_IVM_PROTOCOL *This,
-    IN  EFI_HV_PROTECTION_HANDLE ProtectionHandle
+    IN      EFI_HV_IVM_PROTOCOL *This,
+    IN OUT  EFI_HV_PROTECTION_HANDLE *ProtectionHandle
     )
 /*++
     Makes a chunk of memory not visible to the host.
@@ -1533,15 +1539,23 @@ EfiHvMakeAddressRangeNotHostVisible(
 
 --*/
 {
-    EFI_STATUS status;
+    if (ProtectionHandle == NULL || *ProtectionHandle == NULL)
+    {
+        // fail fast here as this error either indicates a double free or another address range
+        // is not made private, which can cause a security issue due to unexpected host visibility.
+        FAIL_FAST(EFI_INVALID_PARAMETER, "Invalid protection handle"); 
+    }
 
-    RemoveEntryList(&ProtectionHandle->ListEntry);
+    EFI_STATUS status;
+    EFI_HV_PROTECTION_OBJECT *ProtectionObject = (EFI_HV_PROTECTION_OBJECT *)(*ProtectionHandle);
+
+    RemoveEntryList(&ProtectionObject->ListEntry);
 
     status =
         EfiHvpModifySparseGpaPageHostVisibility(
             HV_MAP_GPA_PERMISSIONS_NONE,
-            ProtectionHandle->NumberOfPages,
-            ProtectionHandle->GpaPageBase,
+            ProtectionObject->NumberOfPages,
+            ProtectionObject->GpaPageBase,
             NULL);
     if (EFI_ERROR(status))
     {
@@ -1551,6 +1565,9 @@ EfiHvMakeAddressRangeNotHostVisible(
         //
         FAIL_FAST_UNEXPECTED_HOST_BEHAVIOR();
     }
+
+    FreePool(ProtectionObject);
+    *ProtectionHandle = NULL;
 }
 
 
@@ -1861,7 +1878,7 @@ EfiHvDisconnectFromHypervisor (
     {
         entry = GetFirstNode(&mHostVisiblePageList);
         protectionObject = BASE_CR(entry, EFI_HV_PROTECTION_OBJECT, ListEntry);
-        EfiHvMakeAddressRangeNotHostVisible(NULL, protectionObject);
+        EfiHvMakeAddressRangeNotHostVisible(NULL, &protectionObject);
     }
 
     //

--- a/MsvmPkg/EmclDxe/Emcl.c
+++ b/MsvmPkg/EmclDxe/Emcl.c
@@ -2796,7 +2796,7 @@ Return Value:
 {
     if (Block->IsHostVisible)
     {
-        mHv->MakeAddressRangeNotHostVisible(mHv, Block->ProtectionHandle);
+        mHv->MakeAddressRangeNotHostVisible(mHv, &Block->ProtectionHandle);
     }
 
     if (Block->BouncePageStructureBase)

--- a/MsvmPkg/EventLogDxe/EventLogger.c
+++ b/MsvmPkg/EventLogDxe/EventLogger.c
@@ -397,7 +397,7 @@ Return Value:
 
     if (IsHardwareIsolatedNoParavisor() && hostEmulatorsPresent)
     {
-        mHvIvm->MakeAddressRangeNotHostVisible(mHvIvm, protectionHandle);
+        mHvIvm->MakeAddressRangeNotHostVisible(mHvIvm, &protectionHandle);
     }
 
     channel->Stats.Flush++;

--- a/MsvmPkg/Include/Protocol/EfiHv.h
+++ b/MsvmPkg/Include/Protocol/EfiHv.h
@@ -177,8 +177,8 @@ EFI_STATUS
 typedef
 VOID
 (EFIAPI *EFI_HV_MAKE_ADDRESS_RANGE_NOT_HOST_VISIBLE)(
-    IN  EFI_HV_IVM_PROTOCOL *This,
-    IN  EFI_HV_PROTECTION_HANDLE ProtectionHandle
+    IN      EFI_HV_IVM_PROTOCOL *This,
+    IN OUT  EFI_HV_PROTECTION_HANDLE *ProtectionHandle
     );
 
 // Interface to Hypervisor for the Isolated VM (IVM) calls

--- a/MsvmPkg/NvmExpressDxe/NvmExpress.c
+++ b/MsvmPkg/NvmExpressDxe/NvmExpress.c
@@ -1081,7 +1081,7 @@ NvmExpressDriverCleanUpQueues (
     }
     // MS_HYP_CHANGE END
 
-    Status             = Private->PciIo->FreeBuffer (Private->PciIo, QueuePairPageCount, Private->Buffer);
+    Status = Private->PciIo->FreeBuffer (Private->PciIo, QueuePairPageCount, Private->Buffer);
 
     if (EFI_ERROR (Status)) {
       ReturnStatus = Status;
@@ -1116,7 +1116,7 @@ NvmExpressDriverCleanUpQueues (
       NvmExpressMakeAddressRangePrivate (&Private->IoQueueVisibilityContext, Private->IoQueueBuffer);
     }
     // MS_HYP_CHANGE END
-    Status             = Private->PciIo->FreeBuffer (Private->PciIo, QueuePairPageCount*Private->NumberOfIoQueuePairs, Private->IoQueueBuffer);
+    Status = Private->PciIo->FreeBuffer (Private->PciIo, QueuePairPageCount*Private->NumberOfIoQueuePairs, Private->IoQueueBuffer);
 
     if (EFI_ERROR (Status)) {
       ReturnStatus = Status;

--- a/MsvmPkg/NvmExpressDxe/NvmExpress.c
+++ b/MsvmPkg/NvmExpressDxe/NvmExpress.c
@@ -173,14 +173,20 @@ EnumerateNvmeDevNamespace (
     Device->BlockIo.WriteBlocks = NvmeBlockIoWriteBlocks;
     Device->BlockIo.FlushBlocks = NvmeBlockIoFlushBlocks;
 
-    //
-    // Create BlockIo2 Protocol instance
-    //
-    Device->BlockIo2.Media         = &Device->Media;
-    Device->BlockIo2.Reset         = NvmeBlockIoResetEx;
-    Device->BlockIo2.ReadBlocksEx  = NvmeBlockIoReadBlocksEx;
-    Device->BlockIo2.WriteBlocksEx = NvmeBlockIoWriteBlocksEx;
-    Device->BlockIo2.FlushBlocksEx = NvmeBlockIoFlushBlocksEx;
+    // MU_CHANGE [BEGIN] - Request Number of Queues from Controller
+    if (NVME_SUPPORT_BLOCKIO2 (Private)) {
+      // We have multiple data queues, so we can support the BlockIo2 protocol
+
+      // Create BlockIo2 Protocol instance
+      Device->BlockIo2.Media         = &Device->Media;
+      Device->BlockIo2.Reset         = NvmeBlockIoResetEx;
+      Device->BlockIo2.ReadBlocksEx  = NvmeBlockIoReadBlocksEx;
+      Device->BlockIo2.WriteBlocksEx = NvmeBlockIoWriteBlocksEx;
+      Device->BlockIo2.FlushBlocksEx = NvmeBlockIoFlushBlocksEx;
+    }
+
+    // MU_CHANGE [END] - Request Number of Queues from Controller
+
     InitializeListHead (&Device->AsyncQueue);
 
     //
@@ -259,8 +265,8 @@ EnumerateNvmeDevNamespace (
                     Device->DevicePath,
                     &gEfiBlockIoProtocolGuid,
                     &Device->BlockIo,
-                    &gEfiBlockIo2ProtocolGuid,
-                    &Device->BlockIo2,
+                    // &gEfiBlockIo2ProtocolGuid, // MU_CHANGE - Request Number of Queues from Controller
+                    // &Device->BlockIo2, // MU_CHANGE - Request Number of Queues from Controller
                     &gEfiDiskInfoProtocolGuid,
                     &Device->DiskInfo,
                     &gMediaSanitizeProtocolGuid,
@@ -271,6 +277,36 @@ EnumerateNvmeDevNamespace (
     if (EFI_ERROR (Status)) {
       goto Exit;
     }
+
+    // MU_CHANGE [BEGIN] - Request Number of Queues from Controller
+    if (NVME_SUPPORT_BLOCKIO2 (Private)) {
+      // We have multiple data queues, so we can support the BlockIo2 protocol
+      Status = gBS->InstallMultipleProtocolInterfaces (
+                      &Device->DeviceHandle,
+                      &gEfiBlockIo2ProtocolGuid,
+                      &Device->BlockIo2,
+                      NULL
+                      );
+
+      if (EFI_ERROR (Status)) {
+        gBS->UninstallMultipleProtocolInterfaces (
+               Device->DeviceHandle,
+               &gEfiDevicePathProtocolGuid,
+               Device->DevicePath,
+               &gEfiBlockIoProtocolGuid,
+               &Device->BlockIo,
+               &gEfiDiskInfoProtocolGuid,
+               &Device->DiskInfo,
+               NULL
+               );
+
+        DEBUG ((DEBUG_ERROR, "%a: Failed to install BlockIo2 protocol. Error %r\n", __func__, Status));
+        ASSERT_EFI_ERROR (Status);
+        goto Exit;
+      }
+    }
+
+    // MU_CHANGE [END] - Request Number of Queues from Controller
 
     //
     // Check if the NVMe controller supports the Security Send and Security Receive commands
@@ -289,14 +325,28 @@ EnumerateNvmeDevNamespace (
                Device->DevicePath,
                &gEfiBlockIoProtocolGuid,
                &Device->BlockIo,
-               &gEfiBlockIo2ProtocolGuid,
-               &Device->BlockIo2,
+               // &gEfiBlockIo2ProtocolGuid, // MU_CHANGE - Request Number of Queues from Controller
+               // &Device->BlockIo2, // MU_CHANGE - Request Number of Queues from Controller
                &gEfiDiskInfoProtocolGuid,
                &Device->DiskInfo,
                &gMediaSanitizeProtocolGuid,
                &Device->MediaSanitize,
                NULL
                );
+
+        // MU_CHANGE [BEGIN] - Request Number of Queues from Controller
+        if (NVME_SUPPORT_BLOCKIO2 (Private)) {
+          // We have multiple data queues, so we need to uninstall the BlockIo2 protocol
+          gBS->UninstallMultipleProtocolInterfaces (
+                 Device->DeviceHandle,
+                 &gEfiBlockIo2ProtocolGuid,
+                 &Device->BlockIo2,
+                 NULL
+                 );
+        }
+
+        // MU_CHANGE [END] - Request Number of Queues from Controller
+
         goto Exit;
       }
     }
@@ -438,6 +488,7 @@ UnregisterNvmeNamespace (
   )
 {
   EFI_STATUS                             Status;
+  EFI_STATUS                             BlockIo2Status; // MU_CHANGE - Request Number of Queues from Controller
   EFI_BLOCK_IO_PROTOCOL                  *BlockIo;
   NVME_DEVICE_PRIVATE_DATA               *Device;
   EFI_STORAGE_SECURITY_COMMAND_PROTOCOL  *StorageSecurity;
@@ -445,7 +496,10 @@ UnregisterNvmeNamespace (
   EFI_TPL                                OldTpl;
   VOID                                   *DummyInterface;
 
-  BlockIo = NULL;
+  // MU_CHANGE [BEGIN] - Request Number of Queues from Controller
+  BlockIo        = NULL;
+  BlockIo2Status = EFI_SUCCESS;
+  // MU_CHANGE [END] - Request Number of Queues from Controller
 
   Status = gBS->OpenProtocol (
                   Handle,
@@ -486,6 +540,24 @@ UnregisterNvmeNamespace (
          Handle
          );
 
+  // MU_CHANGE [BEGIN] - Request Number of Queues from Controller
+  //
+  // If BlockIo2 is installed, uninstall it.
+  //
+  if (NVME_SUPPORT_BLOCKIO2 (Device->Controller)) {
+    BlockIo2Status = gBS->UninstallMultipleProtocolInterfaces (
+                            Handle,
+                            &gEfiBlockIo2ProtocolGuid,
+                            &Device->BlockIo2,
+                            NULL
+                            );
+
+    if (EFI_ERROR (BlockIo2Status)) {
+      DEBUG ((DEBUG_ERROR, "%a: Failed to uninstall BlockIo2 protocol\n", __func__));
+    }
+  }
+
+  // MU_CHANGE [END] - Request Number of Queues from Controller
   //
   // The Nvm Express driver installs the BlockIo and DiskInfo in the DriverBindingStart().
   // Here should uninstall both of them.
@@ -496,8 +568,8 @@ UnregisterNvmeNamespace (
                   Device->DevicePath,
                   &gEfiBlockIoProtocolGuid,
                   &Device->BlockIo,
-                  &gEfiBlockIo2ProtocolGuid,
-                  &Device->BlockIo2,
+                  // &gEfiBlockIo2ProtocolGuid, // MU_CHANGE - Request Number of Queues from Controller
+                  // &Device->BlockIo2, // MU_CHANGE - Request Number of Queues from Controller
                   &gEfiDiskInfoProtocolGuid,
                   &Device->DiskInfo,
                   &gMediaSanitizeProtocolGuid,
@@ -505,7 +577,8 @@ UnregisterNvmeNamespace (
                   NULL
                   );
 
-  if (EFI_ERROR (Status)) {
+  if (EFI_ERROR (Status) || EFI_ERROR (BlockIo2Status)) {
+    // MU_CHANGE - Request Number of Queues from Controller
     gBS->OpenProtocol (
            Controller,
            &gEfiNvmExpressPassThruProtocolGuid,
@@ -957,6 +1030,108 @@ Done:
   return Status;
 }
 
+// MU_CHANGE [BEGIN] - Allocate IO Queue Buffer
+
+/**
+  Unmap the queues from PciIo and free the buffers allocated.
+
+  @param[in]  Private  The pointer to the NVME_CONTROLLER_PRIVATE_DATA data structure.
+
+  @retval EFI_SUCCESS           The queues are successfully cleaned up.
+  @return Others                Some error occurs when cleaning up the queues.
+
+**/
+EFI_STATUS
+EFIAPI
+NvmExpressDriverCleanUpQueues (
+  IN NVME_CONTROLLER_PRIVATE_DATA  *Private
+  )
+{
+  EFI_STATUS  Status;
+  EFI_STATUS  ReturnStatus;
+  UINTN       QueuePairPageCount;
+
+  ReturnStatus = EFI_SUCCESS;
+
+  if (Private == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  //
+  // Admin Queue Clean-up
+  //
+  if (Private->Mapping != NULL) {
+    Status = Private->PciIo->Unmap (Private->PciIo, Private->Mapping);
+    if (EFI_ERROR (Status)) {
+      ReturnStatus = Status;
+      DEBUG ((DEBUG_ERROR, "%a: Unmap Admin Queue Mapping failed %r\n", __func__, Status));
+      ASSERT_EFI_ERROR (Status);
+    }
+
+    Private->Mapping = NULL;
+  }
+
+  if (Private->Buffer != NULL) {
+    QueuePairPageCount = NVME_SQ_SIZE_IN_PAGES (Private, 0) + NVME_CQ_SIZE_IN_PAGES (Private, 0);
+
+    // MS_HYP_CHANGE BEGIN
+    if (IsIsolated ()) {
+      NvmExpressMakeAddressRangePrivate (&Private->QueueVisibilityContext, Private->Buffer);
+      
+    }
+    // MS_HYP_CHANGE END
+
+    Status             = Private->PciIo->FreeBuffer (Private->PciIo, QueuePairPageCount, Private->Buffer);
+
+    if (EFI_ERROR (Status)) {
+      ReturnStatus = Status;
+      DEBUG ((DEBUG_ERROR, "%a: FreeBuffer Buffer failed %r\n", __func__, Status));
+      ASSERT_EFI_ERROR (Status);
+    }
+
+    Private->Buffer = NULL;
+  }
+
+  //
+  // I/O Queue Clean-up
+  //
+  if (Private->IoQueueMapping != NULL) {
+    Status = Private->PciIo->Unmap (Private->PciIo, Private->IoQueueMapping);
+
+    if (EFI_ERROR (Status)) {
+      ReturnStatus = Status;
+      DEBUG ((DEBUG_ERROR, "%a: Unmap IoQueueMapping failed %r\n", __func__, Status));
+      ASSERT_EFI_ERROR (Status);
+    }
+
+    Private->IoQueueMapping = NULL;
+  }
+
+  if (Private->IoQueueBuffer != NULL) {
+    // Using the first data queue size for the number of pages required for the data queues
+    QueuePairPageCount = NVME_SQ_SIZE_IN_PAGES (Private, 1) + NVME_CQ_SIZE_IN_PAGES (Private, 1);
+
+    // MS_HYP_CHANGE BEGIN
+    if (IsIsolated()) {
+      NvmExpressMakeAddressRangePrivate (&Private->IoQueueVisibilityContext, Private->IoQueueBuffer);
+    }
+    // MS_HYP_CHANGE END
+    Status             = Private->PciIo->FreeBuffer (Private->PciIo, QueuePairPageCount*Private->NumberOfIoQueuePairs, Private->IoQueueBuffer);
+
+    if (EFI_ERROR (Status)) {
+      ReturnStatus = Status;
+      DEBUG ((DEBUG_ERROR, "%a: FreeBuffer IoQueueBuffer failed %r\n", __func__, Status));
+      ASSERT_EFI_ERROR (Status);
+    }
+
+    Private->IoQueueBuffer = NULL;
+  }
+
+  return ReturnStatus;
+}
+
+// MU_CHANGE [END] - Allocate IO Queue Buffer
+
 /**
   Starts a device controller or a bus controller.
 
@@ -1000,19 +1175,19 @@ NvmExpressDriverBindingStart (
   IN EFI_DEVICE_PATH_PROTOCOL     *RemainingDevicePath
   )
 {
-  EFI_STATUS                          Status;
-  EFI_PCI_IO_PROTOCOL                 *PciIo;
-  NVME_CONTROLLER_PRIVATE_DATA        *Private;
-  EFI_DEVICE_PATH_PROTOCOL            *ParentDevicePath;
-  UINT32                              NamespaceId;
-  EFI_PHYSICAL_ADDRESS                MappedAddr;
-  UINTN                               Bytes;
+  EFI_STATUS                    Status;
+  EFI_PCI_IO_PROTOCOL           *PciIo;
+  NVME_CONTROLLER_PRIVATE_DATA  *Private;
+  EFI_DEVICE_PATH_PROTOCOL      *ParentDevicePath;
+  UINT32                        NamespaceId;
+  // MU_CHANGE [BEGIN] - Allocate IO Queue Buffer
+  // EFI_PHYSICAL_ADDRESS                MappedAddr;
+  // UINTN                               Bytes;
+  // MU_CHANGE [END] - Allocate IO Queue Buffer
+
   EFI_NVM_EXPRESS_PASS_THRU_PROTOCOL  *Passthru;
   BOOLEAN                             FilteringEnabled; // MS_HYP_CHANGE: Filter namespaces
 
-  // MU_CHANGE - Support alternative hardware queue sizes in NVME driver
-  UINTN  QueuePageCount = PcdGetBool (PcdSupportAlternativeQueueSize) ?
-                          NVME_ALTERNATIVE_TOTAL_QUEUE_BUFFER_IN_PAGES : 6;
 
   DEBUG ((DEBUG_INFO, "NvmExpressDriverBindingStart: start\n"));
 
@@ -1084,88 +1259,50 @@ NvmExpressDriverBindingStart (
       DEBUG ((DEBUG_WARN, "NvmExpressDriverBindingStart: failed to enable 64-bit DMA (%r)\n", Status));
     }
 
-    // MU_CHANGE - Support alternative hardware queue sizes in NVME driver
+    // MU_CHANGE [BEGIN] - Allocate IO Queue Buffer
+    // //
+    // // 6 x 4kB aligned buffers will be carved out of this buffer.
+    // // 1st 4kB boundary is the start of the admin submission queue.
+    // // 2nd 4kB boundary is the start of the admin completion queue.
+    // // 3rd 4kB boundary is the start of I/O submission queue #1.
+    // // 4th 4kB boundary is the start of I/O completion queue #1.
+    // // 5th 4kB boundary is the start of I/O submission queue #2.
+    // // 6th 4kB boundary is the start of I/O completion queue #2.
+    // //
+    // // Allocate 6 pages of memory, then map it for bus master read and write.
+    // //
+    // Status = PciIo->AllocateBuffer (
+    //                   PciIo,
+    //                   AllocateAnyPages,
+    //                   EfiBootServicesData,
+    //                   6,
+    //                   (VOID **)&Private->Buffer,
+    //                   0
+    //                   );
+    // if (EFI_ERROR (Status)) {
+    //   goto Exit;
+    // }
 
-    //
-    // Depending on PCD disablement, either support the default or alternative
-    // queue sizes.
-    //
-    // Default:
-    // 6 x 4kB aligned buffers will be carved out of this buffer.
-    // 1st 4kB boundary is the start of the admin submission queue.
-    // 2nd 4kB boundary is the start of the admin completion queue.
-    // 3rd 4kB boundary is the start of I/O submission queue #1.
-    // 4th 4kB boundary is the start of I/O completion queue #1.
-    // 5th 4kB boundary is the start of I/O submission queue #2.
-    // 6th 4kB boundary is the start of I/O completion queue #2.
-    //
-    // Allocate 6 pages of memory, then map it for bus master read and write.
-    //
-    // Alternative:
-    // 15 x 4kB aligned buffers will be carved out of this buffer.
-    // 1st 4kB boundary is the start of the admin submission queue.
-    // 5th 4kB boundary is the start of the admin completion queue.
-    // 6th 4kB boundary is the start of I/O submission queue #1.
-    // 10th 4kB boundary is the start of I/O completion queue #1.
-    // 11th 4kB boundary is the start of I/O submission queue #2.
-    // 15th 4kB boundary is the start of I/O completion queue #2.
-    //
-    // Allocate 15 pages of memory, then map it for bus master read and write.
-    //
-    Status = PciIo->AllocateBuffer (
-                      PciIo,
-                      AllocateAnyPages,
-                      EfiBootServicesData,
-                      QueuePageCount,
-                      (VOID **)&Private->Buffer,
-                      0
-                      );
-    if (EFI_ERROR (Status)) {
-      goto Exit;
-    }
 
-    // MS_HYP_CHANGE BEGIN
-    if (IsIsolated ()) {
-      Status = NvmExpressMakeAddressRangeShared (
-                 &Private->QueueVisibilityContext,
-                 Private->Buffer,
-                 (UINT32)QueuePageCount * EFI_PAGE_SIZE
-                 );
+    // MS_HYP_CHANGE - Support alternative hardware queue sizes in NVME driver
+    // Bytes  = EFI_PAGES_TO_SIZE (QueuePageCount);
+    // Status = PciIo->Map (
+    //                   PciIo,
+    //                   EfiPciIoOperationBusMasterCommonBuffer,
+    //                   Private->Buffer,
+    //                   &Bytes,
+    //                   &MappedAddr,
+    //                   &Private->Mapping
+    //                   );
 
-      if (EFI_ERROR (Status)) {
-        goto Exit;
-      }
-    }
+    // MS_HYP_CHANGE - Support alternative hardware queue sizes in NVME driver
+    // if (EFI_ERROR (Status) || (Bytes != EFI_PAGES_TO_SIZE (QueuePageCount))) {
+    //  goto Exit;
+	// }
+    
 
-    // MS_HYP_CHANGE END
-
-    // MU_CHANGE - Support alternative hardware queue sizes in NVME driver
-    Bytes  = EFI_PAGES_TO_SIZE (QueuePageCount);
-    Status = PciIo->Map (
-                      PciIo,
-                      EfiPciIoOperationBusMasterCommonBuffer,
-                      Private->Buffer,
-                      &Bytes,
-                      &MappedAddr,
-                      &Private->Mapping
-                      );
-
-    // MU_CHANGE - Support alternative hardware queue sizes in NVME driver
-    if (EFI_ERROR (Status) || (Bytes != EFI_PAGES_TO_SIZE (QueuePageCount))) {
-      goto Exit;
-    }
-
-    // MS_HYP_CHANGE BEGIN
-    if (IsIsolated ()) {
-      //
-      // Canonicalize  the VA.
-      //
-      Private->Buffer = NvmExpressGetSharedVa (Private->Buffer);
-    }
-
-    // MS_HYP_CHANGE END
-
-    Private->BufferPciAddr = (UINT8 *)(UINTN)MappedAddr;
+    // Private->BufferPciAddr             = (UINT8 *)(UINTN)MappedAddr;
+    // MU_CHANGE [END] - Allocate IO Queue Buffer
 
     Private->Signature                 = NVME_CONTROLLER_PRIVATE_DATA_SIGNATURE;
     Private->ControllerHandle          = Controller;
@@ -1202,28 +1339,36 @@ NvmExpressDriverBindingStart (
       goto Exit;
     }
 
+    // MU_CHANGE [BEGIN] - Request Number of Queues from Controller
+
     //
     // Start the asynchronous I/O completion monitor
+    // The ProcessAsyncTaskList event and NVME_HC_ASYNC_TIMER timer are only used for the BlockIo2 protocol,
+    // which is only installed when the number of IO queues is greater than 1
     //
-    Status = gBS->CreateEvent (
-                    EVT_TIMER | EVT_NOTIFY_SIGNAL,
-                    TPL_NOTIFY,
-                    ProcessAsyncTaskList,
-                    Private,
-                    &Private->TimerEvent
-                    );
-    if (EFI_ERROR (Status)) {
-      goto Exit;
+    if (NVME_SUPPORT_BLOCKIO2 (Private)) {
+      Status = gBS->CreateEvent (
+                      EVT_TIMER | EVT_NOTIFY_SIGNAL,
+                      TPL_NOTIFY,
+                      ProcessAsyncTaskList,
+                      Private,
+                      &Private->TimerEvent
+                      );
+      if (EFI_ERROR (Status)) {
+        goto Exit;
+      }
+
+      Status = gBS->SetTimer (
+                      Private->TimerEvent,
+                      TimerPeriodic,
+                      NVME_HC_ASYNC_TIMER
+                      );
+      if (EFI_ERROR (Status)) {
+        goto Exit;
+      }
     }
 
-    Status = gBS->SetTimer (
-                    Private->TimerEvent,
-                    TimerPeriodic,
-                    NVME_HC_ASYNC_TIMER
-                    );
-    if (EFI_ERROR (Status)) {
-      goto Exit;
-    }
+    // MU_CHANGE [END] - Request Number of Queues from Controller
 
     Status = gBS->InstallMultipleProtocolInterfaces (
                     &Controller,
@@ -1293,14 +1438,21 @@ NvmExpressDriverBindingStart (
   return EFI_SUCCESS;
 
 Exit:
-  if ((Private != NULL) && (Private->Mapping != NULL)) {
-    PciIo->Unmap (PciIo, Private->Mapping);
+  // MU_CHANGE [BEGIN] - Allocate IO Queue Buffer
+  // if ((Private != NULL) && (Private->Mapping != NULL)) {
+  //   PciIo->Unmap (PciIo, Private->Mapping);
+  // }
+  //
+  // if ((Private != NULL) && (Private->Buffer != NULL)) {
+  //   PciIo->FreeBuffer (PciIo, 6, Private->Buffer);
+  // }
+
+  Status = NvmExpressDriverCleanUpQueues (Private);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: NvmExpressDriverCleanUpQueues failed %r\n", __func__, Status));
   }
 
-  if ((Private != NULL) && (Private->Buffer != NULL)) {
-    // MU_CHANGE - Support alternative hardware queue sizes in NVME driver
-    PciIo->FreeBuffer (PciIo, QueuePageCount, Private->Buffer);
-  }
+  // MU_CHANGE [END] - Allocate IO Queue Buffer
 
   if ((Private != NULL) && (Private->ControllerData != NULL)) {
     FreePool (Private->ControllerData);
@@ -1375,9 +1527,6 @@ NvmExpressDriverBindingStop (
   EFI_NVM_EXPRESS_PASS_THRU_PROTOCOL  *PassThru;
   BOOLEAN                             IsEmpty;
   EFI_TPL                             OldTpl;
-  // MU_CHANGE - Support alternative hardware queue sizes in NVME driver
-  UINT16  QueuePageCount = PcdGetBool (PcdSupportAlternativeQueueSize) ?
-                           NVME_ALTERNATIVE_TOTAL_QUEUE_BUFFER_IN_PAGES : 6;
 
   if (NumberOfChildren == 0) {
     Status = gBS->OpenProtocol (
@@ -1419,20 +1568,21 @@ NvmExpressDriverBindingStop (
         gBS->CloseEvent (Private->TimerEvent);
       }
 
-      if (Private->Mapping != NULL) {
-        Private->PciIo->Unmap (Private->PciIo, Private->Mapping);
+      // MU_CHANGE [BEGIN] - Allocate IO Queue Buffer
+      // if (Private->Mapping != NULL) {
+      //   Private->PciIo->Unmap (Private->PciIo, Private->Mapping);
+      // }
+      //
+      // if (Private->Buffer != NULL) {
+      //   Private->PciIo->FreeBuffer (Private->PciIo, 6, Private->Buffer);
+      // }
+
+      Status = NvmExpressDriverCleanUpQueues (Private);
+      if (EFI_ERROR (Status)) {
+        DEBUG ((DEBUG_ERROR, "%a: NvmExpressDriverCleanUpQueues failed %r\n", __func__, Status));
       }
 
-      if (Private->Buffer != NULL) {
-        // MS_HYP_CHANGE BEGIN
-        if (IsIsolated ()) {
-          NvmExpressMakeAddressRangePrivate (&Private->QueueVisibilityContext, Private->Buffer);
-        }
-
-        // MS_HYP_CHANGE END
-        // MU_CHANGE - Support alternative hardware queue sizes in NVME driver
-        Private->PciIo->FreeBuffer (Private->PciIo, QueuePageCount, Private->Buffer);
-      }
+      // MU_CHANGE [END] - Allocate IO Queue Buffer
 
       NvmExpressFreeAllBounceBlocks (Private);   // MS_HYP_CHANGE
       FreePool (Private->ControllerData);

--- a/MsvmPkg/NvmExpressDxe/NvmExpress.h
+++ b/MsvmPkg/NvmExpressDxe/NvmExpress.h
@@ -42,10 +42,12 @@
 #include <Library/UefiBootServicesTableLib.h>
 #include <Library/UefiDriverEntryPoint.h>
 #include <Library/ReportStatusCodeLib.h>
+
 #include <Guid/NVMeEventGroup.h>
 
 typedef struct _NVME_CONTROLLER_PRIVATE_DATA  NVME_CONTROLLER_PRIVATE_DATA;
 typedef struct _NVME_DEVICE_PRIVATE_DATA      NVME_DEVICE_PRIVATE_DATA;
+typedef struct _NVME_QUEUE_SIZE_DATA          NVME_QUEUE_SIZE_DATA; // MU_CHANGE - Allocate IO Queue Buffer
 
 #include "NvmExpressBlockIo.h"
 #include "NvmExpressBounce.h"   // MS_HYP_CHANGE
@@ -67,6 +69,14 @@ extern EFI_DRIVER_SUPPORTED_EFI_VERSION_PROTOCOL  gNvmExpressDriverSupportedEfiV
 #define NVME_CSQ_SIZE  1                                // Number of I/O submission queue entries, which is 0-based
 #define NVME_CCQ_SIZE  1                                // Number of I/O completion queue entries, which is 0-based
 
+// MU_CHANGE [BEGIN] - Allocate IO Queue Buffer
+// NVM Express 2.0e specification, section 5.17.1 Identify Controller Data Structure (CNS 01h)
+// The specification defines these numbers as the minimum and standard values. They are what this driver supports.
+// The values are in bytes and are reported as a power of 2.
+#define NVME_IOSQES_MIN  6                              // I/O submission queue entry size
+#define NVME_IOCQES_MIN  4                              // I/O completion queue entry size
+// MU_CHANGE [END] - Allocate IO Queue Buffer
+
 //
 // Number of asynchronous I/O submission queue entries, which is 0-based.
 // The asynchronous I/O submission queue size is 4kB in total.
@@ -78,7 +88,30 @@ extern EFI_DRIVER_SUPPORTED_EFI_VERSION_PROTOCOL  gNvmExpressDriverSupportedEfiV
 //
 #define NVME_ASYNC_CCQ_SIZE  255
 
-#define NVME_MAX_QUEUES  3                              // Number of queues supported by the driver
+// MU_CHANGE [BEGIN] - Request Number of Queues from Controller
+// Maximum number of queue pairs supported by the driver, including the admin queues.
+// Queue 0 - Admin
+// Queue 1 - Blocking I/O (BlockIo Protocol)
+// Queue 2 - Asynchronous I/O (BlockIo2 Protocol)
+#define NVME_MAX_QUEUES  3
+
+// Returns if the controller supports the BlockIo2 protocol.
+// The BlockIo2 protocol is only supported if the controller has more than 1 queue pair allocated
+#define NVME_SUPPORT_BLOCKIO2(ContollerPointer)  (((ContollerPointer)->NumberOfIoQueuePairs) > 1)
+// MU_CHANGE [END] - Request Number of Queues from Controller
+
+// MU_CHANGE [BEGIN] - Allocate IO Queue Buffer
+//
+// Returns the number of pages required for a submission/completion queue
+// The Indices are the same as above, 0 for admin, 1 for blocking I/O, 2 for async I/O.
+//
+#define NVME_SQ_SIZE_IN_PAGES(ControllerPointer, Index) \
+  EFI_SIZE_TO_PAGES(((ControllerPointer)->SqData[(Index)].NumberOfEntries * (UINTN)LShiftU64 (2, (ControllerPointer)->SqData[(Index)].EntrySize)))
+
+#define NVME_CQ_SIZE_IN_PAGES(ControllerPointer, Index) \
+  EFI_SIZE_TO_PAGES(((ControllerPointer)->CqData[(Index)].NumberOfEntries * (UINTN)LShiftU64 (2, (ControllerPointer)->CqData[(Index)].EntrySize)))
+
+// MU_CHANGE [END] - Allocate IO Queue Buffer
 
 //
 // FormatNVM Admin Command LBA Format (LBAF) Mask
@@ -114,10 +147,9 @@ extern EFI_DRIVER_SUPPORTED_EFI_VERSION_PROTOCOL  gNvmExpressDriverSupportedEfiV
 // Each submission queue buffer is allocated as 64B * 256 = 4 * 4kB = 4 pages.
 // Each completion queue buffer is allocated as 16B * 256 = 4kB = 1 page.
 //
-#define NVME_ALTERNATIVE_MAX_QUEUE_SIZE               255
-#define NVME_ALTERNATIVE_TOTAL_QUEUE_BUFFER_IN_PAGES  NVME_MAX_QUEUES * 5
+#define NVME_ALTERNATIVE_MAX_QUEUE_SIZE  255
 
-// MU_CHANGE [END]
+// MU_CHANGE [END] - Support alternative hardware queue sizes in NVME driver
 
 #define NVME_CONTROLLER_ID  0
 
@@ -127,7 +159,8 @@ extern EFI_DRIVER_SUPPORTED_EFI_VERSION_PROTOCOL  gNvmExpressDriverSupportedEfiV
 //
 // Time out value for Nvme transaction execution
 //
-#define NVME_GENERIC_TIMEOUT  EFI_TIMER_PERIOD_SECONDS (5)
+// MS_HYP_CHANGE: Extended I/O timeout for Azure
+#define NVME_GENERIC_TIMEOUT  EFI_TIMER_PERIOD_SECONDS (120)
 
 //
 // Nvme async transfer timer interval, set by experience.
@@ -138,6 +171,18 @@ extern EFI_DRIVER_SUPPORTED_EFI_VERSION_PROTOCOL  gNvmExpressDriverSupportedEfiV
 // Unique signature for private data structure.
 //
 #define NVME_CONTROLLER_PRIVATE_DATA_SIGNATURE  SIGNATURE_32 ('N','V','M','E')
+// MU_CHANGE [BEGIN] - Allocate IO Queue Buffer
+#define NVME_INVALID_VID_DID  0xFFFF
+
+//
+// Nvme queue data
+//
+struct _NVME_QUEUE_SIZE_DATA {
+  UINT32    NumberOfEntries; // in number of entries
+  UINT8     EntrySize;       // in bytes, as a power of 2
+};
+
+// MU_CHANGE [END] - Allocate IO Queue Buffer
 
 //
 // Nvme private data structure.
@@ -162,6 +207,24 @@ struct _NVME_CONTROLLER_PRIVATE_DATA {
   //
   NVME_ADMIN_CONTROLLER_DATA            *ControllerData;
 
+  // MU_CHANGE [BEGIN] - Request Number of Queues from Controller
+  //
+  // Number of Queues Allocated by the controller
+  // UEFI always uses a 1:1 submission:completion queue allocation so we
+  // use NumberOfIoQueuePairs to represent the number of data queue pairs allocated.
+  // NumberOfIoQueuePairs = Nsqa = Ncqa
+  //
+  UINT32                  NumberOfIoQueuePairs;
+  // MU_CHANGE [END] - Request Number of Queues from Controller
+
+  // MU_CHANGE [BEGIN] - Allocate IO Queue Buffer
+  //
+  // Queue Size Data
+  //
+  NVME_QUEUE_SIZE_DATA    SqData[NVME_MAX_QUEUES];
+  NVME_QUEUE_SIZE_DATA    CqData[NVME_MAX_QUEUES];
+  // MU_CHANGE [END] - Allocate IO Queue Buffer
+
   //
   // 6 x 4kB aligned buffers will be carved out of this buffer.
   // 1st 4kB boundary is the start of the admin submission queue.
@@ -173,6 +236,11 @@ struct _NVME_CONTROLLER_PRIVATE_DATA {
   //
   UINT8          *Buffer;
   UINT8          *BufferPciAddr;
+
+  // MU_CHANGE [BEGIN] - Allocate IO Queue Buffer
+  UINT8          *IoQueueBuffer;
+  UINT8          *IoQueueBufferPciAddr;
+  // MU_CHANGE [END] - Allocate IO Queue Buffer
 
   //
   // Pointers to 4kB aligned submission & completion queues.
@@ -203,6 +271,7 @@ struct _NVME_CONTROLLER_PRIVATE_DATA {
   NVME_CAP       Cap;
 
   VOID           *Mapping;
+  VOID           *IoQueueMapping; // MU_CHANGE - Allocate IO Queue Buffer
 
   //
   // For Non-blocking operations.
@@ -213,6 +282,7 @@ struct _NVME_CONTROLLER_PRIVATE_DATA {
   // MS_HYP_CHANGE BEGIN
   LIST_ENTRY     BounceBlockListHead;
   NVME_HOST_VISIBILITY_CONTEXT QueueVisibilityContext;
+  NVME_HOST_VISIBILITY_CONTEXT IoQueueVisibilityContext;
   // MS_HYP_CHANGE END
 };
 

--- a/MsvmPkg/NvmExpressDxe/NvmExpressBlockIo.c
+++ b/MsvmPkg/NvmExpressDxe/NvmExpressBlockIo.c
@@ -992,7 +992,7 @@ NvmeBlockIoReset (
 
   Private = Device->Controller;
 
-  Status = NvmeControllerInit (Private);
+  Status = NvmeControllerReset (Private); // MU_CHANGE - Allocate IO Queue Buffer
 
   if (EFI_ERROR (Status)) {
     Status = EFI_DEVICE_ERROR;
@@ -1260,7 +1260,7 @@ NvmeBlockIoResetEx (
 
   OldTpl = gBS->RaiseTPL (TPL_CALLBACK);
 
-  Status = NvmeControllerInit (Private);
+  Status = NvmeControllerReset (Private); // MU_CHANGE - Allocate IO Queue Buffer
 
   if (EFI_ERROR (Status)) {
     Status = EFI_DEVICE_ERROR;

--- a/MsvmPkg/NvmExpressDxe/NvmExpressBounce.c
+++ b/MsvmPkg/NvmExpressDxe/NvmExpressBounce.c
@@ -191,7 +191,7 @@ NvmExpressFreeBounceBlock(
     )
 {
   if (Block->IsHostVisible)  {
-    mHvIvm->MakeAddressRangeNotHostVisible(mHvIvm, Block->ProtectionHandle);
+    mHvIvm->MakeAddressRangeNotHostVisible(mHvIvm, &Block->ProtectionHandle);
   }
 
   if (Block->BouncePageStructureBase) {
@@ -614,7 +614,7 @@ NvmExpressMakeAddressRangePrivate(
 {
   ASSERT(IsIsolated());
 
-  mHvIvm->MakeAddressRangeNotHostVisible(mHvIvm, HostVisibilityContext->RangeProtectionHandle);
+  mHvIvm->MakeAddressRangeNotHostVisible(mHvIvm, &HostVisibilityContext->RangeProtectionHandle);
 
   AddressRange = (VOID *)((UINT64)AddressRange & ~mCanonicalizationMask);
   if ((UINTN)AddressRange >= mSharedGpaBoundary) {

--- a/MsvmPkg/NvmExpressDxe/NvmExpressDxe.inf
+++ b/MsvmPkg/NvmExpressDxe/NvmExpressDxe.inf
@@ -10,7 +10,7 @@
 #
 ##
 
-#Override : 00000002 | MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressDxe.inf | 7e0eadc2c658b4d73335aba27f4a1c0c | 2025-06-11T22-02-17 | 3568dd82badd2e9c331f43c30f119f6c6908497a
+#Override : 00000002 | MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressDxe.inf | 7e0eadc2c658b4d73335aba27f4a1c0c | 2026-02-27T22-48-59 | 187a160e565265c7e9bfdcf157beebef9f2287b9
 
 [Defines]
   INF_VERSION                    = 0x00010005
@@ -83,11 +83,10 @@
   gEfiResetNotificationProtocolGuid           ## CONSUMES
   gEfiHvIvmProtocolGuid                       ## CONSUMES ## MS_HYP_CHANGE
 
-
 [Pcd]
   ## MU_CHANGE [BEGIN] - Support alternative hardware queue sizes in NVME driver
   gEfiMdeModulePkgTokenSpaceGuid.PcdSupportAlternativeQueueSize ## CONSUMES
-  ## MU_CHANGE [END]
+  ## MU_CHANGE [END] - Support alternative hardware queue sizes in NVME driver
   gMsvmPkgTokenSpaceGuid.PcdIsolationSharedGpaBoundary                ## MS_HYP_CHANGE
   gMsvmPkgTokenSpaceGuid.PcdIsolationSharedGpaCanonicalizationBitmask ## MS_HYP_CHANGE
   gMsvmPkgTokenSpaceGuid.PcdNvmeNamespaceFilter                       ## MS_HYP_CHANGE

--- a/MsvmPkg/NvmExpressDxe/NvmExpressHci.c
+++ b/MsvmPkg/NvmExpressDxe/NvmExpressHci.c
@@ -180,6 +180,52 @@ ReadNvmeControllerStatus (
   return EFI_SUCCESS;
 }
 
+// MU_CHANGE [BEGIN] - Allocate IO Queue Buffer
+
+/**
+  Read Nvm Express admin queue attributes register.
+
+  @param  Private          The pointer to the NVME_CONTROLLER_PRIVATE_DATA data structure.
+  @param  Aqa              The buffer used to store the content to be read from admin queue attributes register.
+
+  @return EFI_SUCCESS      Successfully read data from the admin queue attributes register.
+  @return EFI_DEVICE_ERROR Fail to read data from the admin queue attributes register.
+
+**/
+EFI_STATUS
+ReadNvmeAdminQueueAttributes (
+  IN  NVME_CONTROLLER_PRIVATE_DATA  *Private,
+  OUT NVME_AQA                      *Aqa
+  )
+{
+  EFI_PCI_IO_PROTOCOL  *PciIo;
+  EFI_STATUS           Status;
+  UINT32               Data;
+
+  PciIo  = Private->PciIo;
+  Status = PciIo->Mem.Read (
+                        PciIo,
+                        EfiPciIoWidthUint32,
+                        NVME_BAR,
+                        NVME_AQA_OFFSET,
+                        1,
+                        &Data
+                        );
+
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  WriteUnaligned32 ((UINT32 *)Aqa, Data);
+
+  DEBUG ((DEBUG_INFO, "%a: Admin Submission Queue Size (Number of Entries): %d\n", __func__, Aqa->Asqs));
+  DEBUG ((DEBUG_INFO, "%a: Admin Completion Queue Size (Number of Entries): %d\n", __func__, Aqa->Acqs));
+
+  return EFI_SUCCESS;
+}
+
+// MU_CHANGE [END] - Allocate IO Queue Buffer
+
 /**
   Write Nvm Express admin queue attributes register.
 
@@ -199,6 +245,14 @@ WriteNvmeAdminQueueAttributes (
   EFI_PCI_IO_PROTOCOL  *PciIo;
   EFI_STATUS           Status;
   UINT32               Data;
+
+  // MU_CHANGE [BEGIN] - Allocate IO Queue Buffer
+  //
+  // Save Aqa to Private data for later use.
+  //
+  Private->SqData[0].NumberOfEntries = Aqa->Asqs;
+  Private->CqData[0].NumberOfEntries = Aqa->Acqs;
+  // MU_CHANGE [END] - Allocate IO Queue Buffer
 
   PciIo  = Private->PciIo;
   Data   = ReadUnaligned32 ((UINT32 *)Aqa);
@@ -381,10 +435,14 @@ NvmeDisableController (
   return Status;
 }
 
+// MU_CHANGE [BEGIN] - Allocate IO Queue Buffer
+
 /**
-  Enable the Nvm Express controller.
+  Enable the Nvm Express controller. Allocate and write the Controller Configuration data.
 
   @param  Private          The pointer to the NVME_CONTROLLER_PRIVATE_DATA data structure.
+  @param  IoSqEs           The I/O Submission Queue Entry Size.
+  @param  IoCqEs           The I/O Completion Queue Entry Size.
 
   @return EFI_SUCCESS      Successfully enable the controller.
   @return EFI_DEVICE_ERROR Fail to enable the controller.
@@ -393,9 +451,12 @@ NvmeDisableController (
 **/
 EFI_STATUS
 NvmeEnableController (
-  IN NVME_CONTROLLER_PRIVATE_DATA  *Private
+  IN NVME_CONTROLLER_PRIVATE_DATA  *Private,
+  IN UINT8                         IoSqEs,
+  IN UINT8                         IoCqEs
   )
 {
+  // MU_CHANGE [END] - Allocate IO Queue Buffer
   NVME_CC     Cc;
   NVME_CSTS   Csts;
   EFI_STATUS  Status;
@@ -409,9 +470,11 @@ NvmeEnableController (
   // CC.AMS, CC.MPS and CC.CSS are all set to 0.
   //
   ZeroMem (&Cc, sizeof (NVME_CC));
+  // MU_CHANGE [BEGIN] - Allocate IO Queue Buffer
   Cc.En     = 1;
-  Cc.Iosqes = 6;
-  Cc.Iocqes = 4;
+  Cc.Iosqes = IoSqEs;
+  Cc.Iocqes = IoCqEs;
+  // MU_CHANGE [END] - Allocate IO Queue Buffer
 
   Status = WriteNvmeControllerConfiguration (Private, &Cc);
   if (EFI_ERROR (Status)) {
@@ -566,8 +629,103 @@ NvmeIdentifyNamespace (
   return Status;
 }
 
+// MU_CHANGE [BEGIN] - Request Number of Queues from Controller
+
 /**
-  Create io completion queue.
+  Send the Set Features Command to the controller for the number of queues requested.
+  Note that the number of queues allocated may be different from the number of queues requested.
+  The number of data queue pairs allocated is returned and stored in the controller private data structure
+  using the NumberOfIoQueuePairs field.
+
+  @param  Private          The pointer to the NVME_CONTROLLER_PRIVATE_DATA data structure.
+  @param  Ndqpr            The number of data queue pairs requested.
+
+  @return EFI_SUCCESS      Successfully set the number of queues.
+  @return EFI_DEVICE_ERROR Fail to set the number of queues.
+
+**/
+EFI_STATUS
+NvmeSetFeaturesNumberOfQueues (
+  IN OUT NVME_CONTROLLER_PRIVATE_DATA  *Private,
+  IN UINT16                            Ndqpr
+  )
+{
+  EFI_NVM_EXPRESS_PASS_THRU_COMMAND_PACKET  CommandPacket;
+  EFI_NVM_EXPRESS_COMMAND                   Command;
+  EFI_NVM_EXPRESS_COMPLETION                Completion;
+  EFI_STATUS                                Status;
+  NVME_ADMIN_SET_FEATURES_CDW10             SetFeatures;
+  NVME_ADMIN_SET_FEATURES_NUM_QUEUES        NumberOfQueuesRequested;
+  NVME_ADMIN_SET_FEATURES_NUM_QUEUES        NumberOfQueuesAllocated;
+
+  Status = EFI_SUCCESS;
+
+  if (Ndqpr == 0) {
+    DEBUG ((DEBUG_ERROR, "Number of Data Queue Pairs Requested cannot be 0\n"));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  ZeroMem (&CommandPacket, sizeof (EFI_NVM_EXPRESS_PASS_THRU_COMMAND_PACKET));
+  ZeroMem (&Command, sizeof (EFI_NVM_EXPRESS_COMMAND));
+  ZeroMem (&Completion, sizeof (EFI_NVM_EXPRESS_COMPLETION));
+  ZeroMem (&SetFeatures, sizeof (NVME_ADMIN_SET_FEATURES));
+  ZeroMem (&NumberOfQueuesRequested, sizeof (NVME_ADMIN_SET_FEATURES_NUM_QUEUES));
+  ZeroMem (&NumberOfQueuesAllocated, sizeof (NVME_ADMIN_SET_FEATURES_NUM_QUEUES));
+
+  CommandPacket.NvmeCmd        = &Command;
+  CommandPacket.NvmeCompletion = &Completion;
+  CommandPacket.CommandTimeout = NVME_GENERIC_TIMEOUT;
+  CommandPacket.QueueType      = NVME_ADMIN_QUEUE;
+  Command.Nsid                 = 0; // NSID must be set to 0h or FFFFFFFFh for an admin command
+  Command.Cdw0.Opcode          = NVME_ADMIN_SET_FEATURES_CMD;
+
+  // Populate the Set Features Cdw10 and Cdw11 according to Nvm Express 1.3d Spec
+  // Note we subtract 1 from the requested number of queues to get the 0-based value
+  SetFeatures.Bits.Fid             = NVME_FEATURE_NUMBER_OF_QUEUES;
+  NumberOfQueuesRequested.Bits.Ncq = Ndqpr - 1;
+  NumberOfQueuesRequested.Bits.Nsq = Ndqpr - 1;
+  CommandPacket.NvmeCmd->Cdw10     = SetFeatures.Uint32;
+  CommandPacket.NvmeCmd->Cdw11     = NumberOfQueuesRequested.Uint32;
+
+  CommandPacket.NvmeCmd->Flags = CDW10_VALID | CDW11_VALID;
+
+  DEBUG ((DEBUG_INFO, "Number of Data Queue Pairs Requested: %d\n", Ndqpr));
+
+  // Send the Set Features Command for Number of Queues
+  Status = Private->Passthru.PassThru (
+                               &Private->Passthru,
+                               0,
+                               &CommandPacket,
+                               NULL
+                               );
+
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Set Features Command for Number of Queues failed with Status %r\n", Status));
+    return Status;
+  }
+
+  //
+  // Save the number of queues allocated, adding 1 to account for it being a 0-based value.
+  // E.g. if 1 pair of data queues is allocated Nsq=0, Ncq=0, then NumberOfIoQueuePairs=1.
+  // These numbers do not include the admin queues.
+  //
+  NumberOfQueuesAllocated.Uint32 = CommandPacket.NvmeCompletion->DW0;
+  DEBUG ((DEBUG_INFO, "Number of Data Queue Pairs Allocated By Controller: %d, \n", (NumberOfQueuesAllocated.Bits.Nsq + 1)));
+  if ((NumberOfQueuesAllocated.Bits.Nsq + 1) > Ndqpr) {
+    // This driver at maximum supports 2 pairs of data queues. So we will take the minimum of the requested and allocated values.
+    Private->NumberOfIoQueuePairs = Ndqpr;
+  } else {
+    Private->NumberOfIoQueuePairs = NumberOfQueuesAllocated.Bits.Nsq + 1;
+  }
+
+  DEBUG ((DEBUG_INFO, "Number of Data Queue Pairs Supported By Driver: %d, \n", Private->NumberOfIoQueuePairs));
+  return Status;
+}
+
+// MU_CHANGE [END] - Request Number of Queues from Controller
+
+/**
+  Create io completion queue(s).
 
   @param  Private          The pointer to the NVME_CONTROLLER_PRIVATE_DATA data structure.
 
@@ -591,7 +749,11 @@ NvmeCreateIoCompletionQueue (
   Status                 = EFI_SUCCESS;
   Private->CreateIoQueue = TRUE;
 
-  for (Index = 1; Index < NVME_MAX_QUEUES; Index++) {
+  // MU_CHANGE [BEGIN] - Request Number of Queues from Controller
+  // Start from Index 1 because Index 0 is reserved for admin queue
+  for (Index = 1; Index <= Private->NumberOfIoQueuePairs; Index++) {
+    // MU_CHANGE [END] - Request Number of Queues from Controller
+
     ZeroMem (&CommandPacket, sizeof (EFI_NVM_EXPRESS_PASS_THRU_COMMAND_PACKET));
     ZeroMem (&Command, sizeof (EFI_NVM_EXPRESS_COMMAND));
     ZeroMem (&Completion, sizeof (EFI_NVM_EXPRESS_COMPLETION));
@@ -606,18 +768,18 @@ NvmeCreateIoCompletionQueue (
     CommandPacket.CommandTimeout = NVME_GENERIC_TIMEOUT;
     CommandPacket.QueueType      = NVME_ADMIN_QUEUE;
 
+    // MU_CHANGE [BEGIN] - Use the Mqes value from the Cap register
     // MU_CHANGE [BEGIN] - Support alternative hardware queue sizes in NVME driver
     if (PcdGetBool (PcdSupportAlternativeQueueSize)) {
       QueueSize = MIN (NVME_ALTERNATIVE_MAX_QUEUE_SIZE, Private->Cap.Mqes);
     } else if (Index == 1) {
-      QueueSize = NVME_CCQ_SIZE;
-    } else if (Private->Cap.Mqes > NVME_ASYNC_CCQ_SIZE) {
-      QueueSize = NVME_ASYNC_CCQ_SIZE;
+      // MU_CHANGE [END] - Support alternative hardware queue sizes in NVME driver
+      QueueSize = MIN (NVME_CCQ_SIZE, Private->Cap.Mqes);
     } else {
-      QueueSize = Private->Cap.Mqes;
+      QueueSize = MIN (NVME_ASYNC_CCQ_SIZE, Private->Cap.Mqes);
     }
 
-    // MU_CHANGE [END]
+    // MU_CHANGE [END] - Use the Mqes value from the Cap register
 
     CrIoCq.Qid   = Index;
     CrIoCq.Qsize = QueueSize;
@@ -632,6 +794,9 @@ NvmeCreateIoCompletionQueue (
                                  NULL
                                  );
     if (EFI_ERROR (Status)) {
+      // MU_CHANGE [BEGIN] - Request Number of Queues from Controller
+      DEBUG ((DEBUG_ERROR, "%a: Create Completion Queue Command %d failed with Status %r\n", __func__, Index, Status));
+      // MU_CHANGE [END] - Request Number of Queues from Controller
       break;
     }
   }
@@ -666,7 +831,10 @@ NvmeCreateIoSubmissionQueue (
   Status                 = EFI_SUCCESS;
   Private->CreateIoQueue = TRUE;
 
-  for (Index = 1; Index < NVME_MAX_QUEUES; Index++) {
+  // MU_CHANGE [BEGIN] - Request Number of Queues from Controller
+  // Start from Index 1 because Index 0 is reserved for admin queue
+  for (Index = 1; Index <= Private->NumberOfIoQueuePairs; Index++) {
+    // MU_CHANGE [END] - Request Number of Queues from Controller
     ZeroMem (&CommandPacket, sizeof (EFI_NVM_EXPRESS_PASS_THRU_COMMAND_PACKET));
     ZeroMem (&Command, sizeof (EFI_NVM_EXPRESS_COMMAND));
     ZeroMem (&Completion, sizeof (EFI_NVM_EXPRESS_COMPLETION));
@@ -681,18 +849,18 @@ NvmeCreateIoSubmissionQueue (
     CommandPacket.CommandTimeout = NVME_GENERIC_TIMEOUT;
     CommandPacket.QueueType      = NVME_ADMIN_QUEUE;
 
+    // MU_CHANGE [BEGIN] - Use the Mqes value from the Cap register
     // MU_CHANGE [BEGIN] - Support alternative hardware queue sizes in NVME driver
     if (PcdGetBool (PcdSupportAlternativeQueueSize)) {
       QueueSize = MIN (NVME_ALTERNATIVE_MAX_QUEUE_SIZE, Private->Cap.Mqes);
     } else if (Index == 1) {
-      QueueSize = NVME_CCQ_SIZE;
-    } else if (Private->Cap.Mqes > NVME_ASYNC_CCQ_SIZE) {
-      QueueSize = NVME_ASYNC_CCQ_SIZE;
+      // MU_CHANGE [END] - Support alternative hardware queue sizes in NVME driver
+      QueueSize = MIN (NVME_CSQ_SIZE, Private->Cap.Mqes);
     } else {
-      QueueSize = Private->Cap.Mqes;
+      QueueSize = MIN (NVME_ASYNC_CSQ_SIZE, Private->Cap.Mqes);
     }
 
-    // MU_CHANGE [END]
+    // MU_CHANGE [END] - Use the Mqes value from the Cap register
 
     CrIoSq.Qid   = Index;
     CrIoSq.Qsize = QueueSize;
@@ -709,6 +877,9 @@ NvmeCreateIoSubmissionQueue (
                                  NULL
                                  );
     if (EFI_ERROR (Status)) {
+      // MU_CHANGE [BEGIN] - Request Number of Queues from Controller
+      DEBUG ((DEBUG_ERROR, "%a: Create Submission Queue Command %d failed with Status %r\n", __func__, Index, Status));
+      // MU_CHANGE [END] - Request Number of Queues from Controller
       break;
     }
   }
@@ -717,6 +888,143 @@ NvmeCreateIoSubmissionQueue (
 
   return Status;
 }
+
+// MU_CHANGE [BEGIN] - Allocate IO Queue Buffer
+
+/**
+  Initialize the Nvm Express controller Data (IO) Queues
+
+  @param[in] Private                 The pointer to the NVME_CONTROLLER_PRIVATE_DATA data structure.
+
+  @retval EFI_SUCCESS                The NVM Express Controller IO Queues are initialized successfully.
+  @retval Others                     A device error occurred while initializing the IO Queues.
+
+**/
+EFI_STATUS
+NvmeControllerInitIoQueues (
+  IN NVME_CONTROLLER_PRIVATE_DATA  *Private
+  )
+{
+  UINTN       SqPageCount;
+  UINTN       IoQueuePairPageCount;
+  UINT32      Index;
+  EFI_STATUS  Status;
+
+  // Offset completion queue with submission queue size
+  SqPageCount = NVME_SQ_SIZE_IN_PAGES (Private, 1);
+
+  // Calculate the number of pages required for the data queues
+  IoQueuePairPageCount = SqPageCount + NVME_CQ_SIZE_IN_PAGES (Private, 1);
+
+  //
+  // Address of Data I/O submission & completion queue(s).
+  // We are using the same table of buffer pointers that the admin queues are in, so we start the table from Index + 1, but we have a separate
+  // buffer so we start at the beginning of that buffer.
+  //
+  ZeroMem (Private->IoQueueBuffer, EFI_PAGES_TO_SIZE (IoQueuePairPageCount) * Private->NumberOfIoQueuePairs);
+  for (Index = 0; Index < Private->NumberOfIoQueuePairs; Index++) {
+    Private->SqBuffer[Index + 1]        = (NVME_SQ *)(UINTN)(Private->IoQueueBuffer + EFI_PAGES_TO_SIZE (Index * IoQueuePairPageCount));
+    Private->SqBufferPciAddr[Index + 1] = (NVME_SQ *)(UINTN)(Private->IoQueueBufferPciAddr + EFI_PAGES_TO_SIZE (Index * IoQueuePairPageCount));
+    Private->CqBuffer[Index + 1]        = (NVME_CQ *)(UINTN)(Private->IoQueueBuffer + EFI_PAGES_TO_SIZE (Index * IoQueuePairPageCount + SqPageCount));
+    Private->CqBufferPciAddr[Index + 1] = (NVME_CQ *)(UINTN)(Private->IoQueueBufferPciAddr + EFI_PAGES_TO_SIZE (Index * IoQueuePairPageCount + SqPageCount));
+
+    DEBUG ((DEBUG_INFO, "Data IO   Submission Queue (SqBuffer[%d]) = [%016X]\n", Index + 1, Private->SqBuffer[Index + 1]));
+    DEBUG ((DEBUG_INFO, "Data IO   Completion Queue (CqBuffer[%d]) = [%016X]\n", Index + 1, Private->CqBuffer[Index + 1]));
+  }
+
+  //
+  // Create I/O completion queue(s).
+  //
+  Status = NvmeCreateIoCompletionQueue (Private);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  //
+  // Create I/O Submission queue(s).
+  //
+  Status = NvmeCreateIoSubmissionQueue (Private);
+
+  return Status;
+}
+
+// MU_CHANGE [END] - Allocate IO Queue Buffer
+
+// MU_CHANGE [BEGIN] - Allocate IO Queue Buffer
+
+/**
+  Initialize the Nvm Express controller Admin Queues
+
+  @param[in] Private                 The pointer to the NVME_CONTROLLER_PRIVATE_DATA data structure.
+
+  @retval EFI_SUCCESS                The NVM Express Controller is initialized successfully.
+  @retval Others                     A device error occurred while initializing the controller.
+
+**/
+EFI_STATUS
+NvmeControllerInitAdminQueues (
+  IN NVME_CONTROLLER_PRIVATE_DATA  *Private
+  )
+{
+  NVME_ASQ    Asq;
+  NVME_ACQ    Acq;
+  UINTN       AsqPageCount;
+  UINTN       AsqSize;
+  UINTN       AdminQueuePairPageCount;
+  EFI_STATUS  Status;
+
+  // Offset completion queue with submission queue size
+  AsqPageCount = NVME_SQ_SIZE_IN_PAGES (Private, 0);
+  AsqSize      = EFI_PAGES_TO_SIZE (AsqPageCount);
+
+  //
+  // Address of admin submission queue.
+  //
+  // MU_CHANGE - Remove Page Mask
+  Asq = (UINT64)(UINTN)(Private->BufferPciAddr);
+
+  //
+  // Address of admin completion queue.
+  //
+  // MU_CHANGE - Remove Page Mask
+  Acq = (UINT64)(UINTN)(Private->BufferPciAddr + AsqSize);
+
+  // Calculate the number of pages required for the admin queues
+  AdminQueuePairPageCount = AsqPageCount + NVME_CQ_SIZE_IN_PAGES (Private, 0);
+
+  //
+  // Address of Admin I/O submission & completion queues.
+  //
+  ZeroMem (Private->Buffer, EFI_PAGES_TO_SIZE (AdminQueuePairPageCount));
+  Private->SqBuffer[0]        = (NVME_SQ *)(UINTN)(Private->Buffer);
+  Private->SqBufferPciAddr[0] = (NVME_SQ *)(UINTN)(Private->BufferPciAddr);
+  Private->CqBuffer[0]        = (NVME_CQ *)(UINTN)(Private->Buffer + AsqSize);
+  Private->CqBufferPciAddr[0] = (NVME_CQ *)(UINTN)(Private->BufferPciAddr + AsqSize);
+
+  DEBUG ((DEBUG_INFO, "Private->Buffer = [%016X]\n", (UINT64)(UINTN)Private->Buffer));
+  DEBUG ((DEBUG_INFO, "Admin     Submission Queue size (Number of Entries) = [%08X]\n", Private->SqData[0].NumberOfEntries));
+  DEBUG ((DEBUG_INFO, "Admin     Completion Queue size (Number of Entries) = [%08X]\n", Private->CqData[0].NumberOfEntries));
+  DEBUG ((DEBUG_INFO, "Admin     Submission Queue (SqBuffer[0]) = [%016X]\n", Private->SqBuffer[0]));
+  DEBUG ((DEBUG_INFO, "Admin     Completion Queue (CqBuffer[0]) = [%016X]\n", Private->CqBuffer[0]));
+
+  //
+  // Program admin submission queue address.
+  //
+  Status = WriteNvmeAdminSubmissionQueueBaseAddress (Private, &Asq);
+
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  //
+  // Program admin completion queue address.
+  //
+  Status = WriteNvmeAdminCompletionQueueBaseAddress (Private, &Acq);
+
+  return Status;
+}
+
+// MU_CHANGE [END] - Allocate IO Queue Buffer
 
 /**
   Initialize the Nvm Express controller.
@@ -732,15 +1040,23 @@ NvmeControllerInit (
   IN NVME_CONTROLLER_PRIVATE_DATA  *Private
   )
 {
+  // MU_CHANGE [BEGIN] - Allocate IO Queue Buffer
   EFI_STATUS           Status;
   EFI_PCI_IO_PROTOCOL  *PciIo;
   UINT64               Supports;
-  NVME_AQA             Aqa;
-  NVME_ASQ             Asq;
-  NVME_ACQ             Acq;
-  UINT16               VidDid[2]; // MU_CHANGE - Improve NVMe controller init robustness
-  UINT8                Sn[21];
-  UINT8                Mn[41];
+  UINT16               VidDid[2];  // MU_CHANGE - Improve NVMe controller init robustness
+  // NVME_ASQ             Asq;
+  // NVME_ACQ             Acq;
+  UINT8                 Sn[21];
+  UINT8                 Mn[41];
+  UINTN                 Bytes;
+  UINT32                Index;
+  EFI_PHYSICAL_ADDRESS  MappedAddr;
+  NVME_AQA              Aqa;
+  UINTN                 AdminQueuePairPageCount;
+  UINTN                 IoQueuePairPageCount;
+
+  // MU_CHANGE [END] - Allocate IO Queue Buffer
 
   // MU_CHANGE [BEGIN] - Improve NVMe controller init robustness
   PciIo = Private->PciIo;
@@ -760,14 +1076,15 @@ NvmeControllerInit (
     return EFI_DEVICE_ERROR;
   }
 
-  if ((VidDid[0] == 0xFFFF) || (VidDid[1] == 0xFFFF)) {
+  if ((VidDid[0] == NVME_INVALID_VID_DID) || (VidDid[1] == NVME_INVALID_VID_DID)) {
     return EFI_DEVICE_ERROR;
   }
+
+  // MU_CHANGE [END] - Improve NVMe controller init robustness
 
   //
   // Enable this controller.
   //
-  // MU_CHANGE [END] - Improve NVMe controller init robustness
   Status = PciIo->Attributes (
                     PciIo,
                     EfiPciIoAttributeOperationSupported,
@@ -806,7 +1123,6 @@ NvmeControllerInit (
   //
   // Currently the driver only supports 4k page size.
   //
-
   // MU_CHANGE [BEGIN] - Improve NVMe controller init robustness
 
   // Currently, this means Cap.Mpsmin must be zero for an EFI_PAGE_SHIFT size of 12.
@@ -818,95 +1134,161 @@ NvmeControllerInit (
 
   // MU_CHANGE [END] - Improve NVMe controller init robustness
 
-  Private->Cid[0]        = 0;
-  Private->Cid[1]        = 0;
-  Private->Cid[2]        = 0;
-  Private->Pt[0]         = 0;
-  Private->Pt[1]         = 0;
-  Private->Pt[2]         = 0;
-  Private->SqTdbl[0].Sqt = 0;
-  Private->SqTdbl[1].Sqt = 0;
-  Private->SqTdbl[2].Sqt = 0;
-  Private->CqHdbl[0].Cqh = 0;
-  Private->CqHdbl[1].Cqh = 0;
-  Private->CqHdbl[2].Cqh = 0;
-  Private->AsyncSqHead   = 0;
+  // MU_CHANGE [BEGIN] - Allocate IO Queue Buffer
 
+  // Private->Cid[0]        = 0;
+  // Private->Cid[1]        = 0;
+  // Private->Cid[2]        = 0;
+  // Private->Pt[0]         = 0;
+  // Private->Pt[1]         = 0;
+  // Private->Pt[2]         = 0;
+  // Private->SqTdbl[0].Sqt = 0;
+  // Private->SqTdbl[1].Sqt = 0;
+  // Private->SqTdbl[2].Sqt = 0;
+  // Private->CqHdbl[0].Cqh = 0;
+  // Private->CqHdbl[1].Cqh = 0;
+  // Private->CqHdbl[2].Cqh = 0;
+  // Private->AsyncSqHead   = 0;
+
+  for (Index = 0; Index < NVME_MAX_QUEUES; Index++) {
+    Private->Cid[Index]        = 0;
+    Private->Pt[Index]         = 0;
+    Private->SqTdbl[Index].Sqt = 0;
+    Private->CqHdbl[Index].Cqh = 0;
+  }
+
+  Private->AsyncSqHead = 0;
+
+  //
+  // set number of entries admin submission & completion queues.
+  //
+  // MU_CHANGE [BEGIN] - Support alternative hardware queue sizes in NVME driver
+  Aqa.Asqs  = PcdGetBool (PcdSupportAlternativeQueueSize) ? MIN (NVME_ALTERNATIVE_MAX_QUEUE_SIZE, Private->Cap.Mqes) : MIN (NVME_ASQ_SIZE, Private->Cap.Mqes);
+  Aqa.Rsvd1 = 0;
+  Aqa.Acqs  = PcdGetBool (PcdSupportAlternativeQueueSize) ? MIN (NVME_ALTERNATIVE_MAX_QUEUE_SIZE, Private->Cap.Mqes) : MIN (NVME_ACQ_SIZE, Private->Cap.Mqes);
+  Aqa.Rsvd2 = 0;
+  // MU_CHANGE [END] - Support alternative hardware queue sizes in NVME driver
+
+  //
+  // Set admin queue entry size to default
+  // Note we are using the spec-defined minimum SQES and CQES here.
+  //
+  Private->SqData[0].EntrySize       = NVME_IOSQES_MIN;
+  Private->SqData[0].NumberOfEntries = Aqa.Asqs;
+  Private->CqData[0].EntrySize       = NVME_IOCQES_MIN;
+  Private->CqData[0].NumberOfEntries = Aqa.Acqs;
+
+  // Calculate the number of pages required for the admin queues
+  AdminQueuePairPageCount = NVME_SQ_SIZE_IN_PAGES (Private, 0) + NVME_CQ_SIZE_IN_PAGES (Private, 0);
+
+  //
+  // Default:
+  // 6 x 4kB aligned buffers will be carved out of this buffer.
+  // 1st 4kB boundary is the start of the admin submission queue.
+  // 2nd 4kB boundary is the start of the admin completion queue.
+  // 3rd 4kB boundary is the start of I/O submission queue #1.
+  // 4th 4kB boundary is the start of I/O completion queue #1.
+  // 5th 4kB boundary is the start of I/O submission queue #2.
+  // 6th 4kB boundary is the start of I/O completion queue #2.
+  //
+  // Allocate 6 pages of memory, then map it for bus master read and write.
+  //
+  Status = PciIo->AllocateBuffer (
+                    PciIo,
+                    AllocateAnyPages,
+                    EfiBootServicesData,
+                    AdminQueuePairPageCount,
+                    (VOID **)&Private->Buffer,
+                    0
+                    );
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  // MS_HYP_CHANGE BEGIN
+  if (IsIsolated()) {
+    Status = NvmExpressMakeAddressRangeShared(&Private->QueueVisibilityContext,
+                                              Private->Buffer,
+                                              (UINT32)AdminQueuePairPageCount * EFI_PAGE_SIZE
+                                              );
+
+    if (EFI_ERROR(Status)) {
+      return Status;
+    }
+  }
+  // MS_HYP_CHANGE END
+
+  Bytes  = EFI_PAGES_TO_SIZE (AdminQueuePairPageCount);
+  Status = PciIo->Map (
+                    PciIo,
+                    EfiPciIoOperationBusMasterCommonBuffer,
+                    Private->Buffer,
+                    &Bytes,
+                    &MappedAddr,
+                    &Private->Mapping
+                    );
+  if (EFI_ERROR (Status) || (Bytes != EFI_PAGES_TO_SIZE (AdminQueuePairPageCount))) {
+    return EFI_DEVICE_ERROR;
+  }
+
+  // MS_HYP_CHANGE BEGIN
+  if (IsIsolated()) {
+    //
+    // Canonicalize  the VA.
+    //
+    Private->Buffer = NvmExpressGetSharedVa(Private->Buffer);
+  }
+  // MS_HYP_CHANGE END
+
+  Private->BufferPciAddr = (UINT8 *)(UINTN)MappedAddr;
+
+  // Disable the controller to wait for CSTS.RDY to become 0
+  // NVMe Base Specification 2.0e, Section 3.5 Controller Initialization
+  // MU_CHANGE [END] - Allocate IO Queue Buffer
   Status = NvmeDisableController (Private);
 
   if (EFI_ERROR (Status)) {
     return Status;
   }
 
-  //
-  // set number of entries admin submission & completion queues.
-  //
-  // MU_CHANGE [BEGIN] - Support alternative hardware queue sizes in NVME driver
-  Aqa.Asqs  = PcdGetBool (PcdSupportAlternativeQueueSize) ? MIN (NVME_ALTERNATIVE_MAX_QUEUE_SIZE, Private->Cap.Mqes) : NVME_ASQ_SIZE;
-  Aqa.Rsvd1 = 0;
-  Aqa.Acqs  = PcdGetBool (PcdSupportAlternativeQueueSize) ? MIN (NVME_ALTERNATIVE_MAX_QUEUE_SIZE, Private->Cap.Mqes) : NVME_ACQ_SIZE;
-  Aqa.Rsvd2 = 0;
-  // MU_CHANGE [END]
-
+  // MU_CHANGE [BEGIN] - Allocate IO Queue Buffer
   //
   // Address of admin submission queue.
   //
-  Asq = (UINT64)(UINTN)(Private->BufferPciAddr) & ~0xFFF;
+  // MU_CHANGE - Remove the page mask since the buffer is allocated using AllocatePages
+  // Asq = (UINT64)(UINTN)(Private->BufferPciAddr);
 
   //
   // Address of admin completion queue.
   //
-  // MU_CHANGE [BEGIN] - Support alternative hardware queue sizes in NVME driver
-  if (PcdGetBool (PcdSupportAlternativeQueueSize)) {
-    Acq = (UINT64)(UINTN)(Private->BufferPciAddr + 4 * EFI_PAGE_SIZE) & ~0xFFF;
-  } else {
-    Acq = (UINT64)(UINTN)(Private->BufferPciAddr + EFI_PAGE_SIZE) & ~0xFFF;
-  }
+  // MU_CHANGE - Remove the page mask since the buffer is allocated using AllocatePages
+  // Acq = (UINT64)(UINTN)(Private->BufferPciAddr + EFI_PAGE_SIZE);
 
   //
   // Address of I/O submission & completion queue.
   //
-  if (PcdGetBool (PcdSupportAlternativeQueueSize)) {
-    ZeroMem (Private->Buffer, EFI_PAGES_TO_SIZE (NVME_ALTERNATIVE_TOTAL_QUEUE_BUFFER_IN_PAGES));
-    Private->SqBuffer[0]        = (NVME_SQ *)(UINTN)(Private->Buffer);
-    Private->SqBufferPciAddr[0] = (NVME_SQ *)(UINTN)(Private->BufferPciAddr);
-    Private->CqBuffer[0]        = (NVME_CQ *)(UINTN)(Private->Buffer + 4 * EFI_PAGE_SIZE);
-    Private->CqBufferPciAddr[0] = (NVME_CQ *)(UINTN)(Private->BufferPciAddr + 4 * EFI_PAGE_SIZE);
-    Private->SqBuffer[1]        = (NVME_SQ *)(UINTN)(Private->Buffer + 5 * EFI_PAGE_SIZE);
-    Private->SqBufferPciAddr[1] = (NVME_SQ *)(UINTN)(Private->BufferPciAddr + 5 * EFI_PAGE_SIZE);
-    Private->CqBuffer[1]        = (NVME_CQ *)(UINTN)(Private->Buffer + 9 * EFI_PAGE_SIZE);
-    Private->CqBufferPciAddr[1] = (NVME_CQ *)(UINTN)(Private->BufferPciAddr + 9 * EFI_PAGE_SIZE);
-    Private->SqBuffer[2]        = (NVME_SQ *)(UINTN)(Private->Buffer + 10 * EFI_PAGE_SIZE);
-    Private->SqBufferPciAddr[2] = (NVME_SQ *)(UINTN)(Private->BufferPciAddr + 10 * EFI_PAGE_SIZE);
-    Private->CqBuffer[2]        = (NVME_CQ *)(UINTN)(Private->Buffer + 14 * EFI_PAGE_SIZE);
-    Private->CqBufferPciAddr[2] = (NVME_CQ *)(UINTN)(Private->BufferPciAddr + 14 * EFI_PAGE_SIZE);
-  } else {
-    ZeroMem (Private->Buffer, EFI_PAGES_TO_SIZE (6));
-    Private->SqBuffer[0]        = (NVME_SQ *)(UINTN)(Private->Buffer);
-    Private->SqBufferPciAddr[0] = (NVME_SQ *)(UINTN)(Private->BufferPciAddr);
-    Private->CqBuffer[0]        = (NVME_CQ *)(UINTN)(Private->Buffer + 1 * EFI_PAGE_SIZE);
-    Private->CqBufferPciAddr[0] = (NVME_CQ *)(UINTN)(Private->BufferPciAddr + 1 * EFI_PAGE_SIZE);
-    Private->SqBuffer[1]        = (NVME_SQ *)(UINTN)(Private->Buffer + 2 * EFI_PAGE_SIZE);
-    Private->SqBufferPciAddr[1] = (NVME_SQ *)(UINTN)(Private->BufferPciAddr + 2 * EFI_PAGE_SIZE);
-    Private->CqBuffer[1]        = (NVME_CQ *)(UINTN)(Private->Buffer + 3 * EFI_PAGE_SIZE);
-    Private->CqBufferPciAddr[1] = (NVME_CQ *)(UINTN)(Private->BufferPciAddr + 3 * EFI_PAGE_SIZE);
-    Private->SqBuffer[2]        = (NVME_SQ *)(UINTN)(Private->Buffer + 4 * EFI_PAGE_SIZE);
-    Private->SqBufferPciAddr[2] = (NVME_SQ *)(UINTN)(Private->BufferPciAddr + 4 * EFI_PAGE_SIZE);
-    Private->CqBuffer[2]        = (NVME_CQ *)(UINTN)(Private->Buffer + 5 * EFI_PAGE_SIZE);
-    Private->CqBufferPciAddr[2] = (NVME_CQ *)(UINTN)(Private->BufferPciAddr + 5 * EFI_PAGE_SIZE);
-  }
+  // ZeroMem (Private->Buffer, EFI_PAGES_TO_SIZE (6));
+  // Private->SqBuffer[0]        = (NVME_SQ *)(UINTN)(Private->Buffer);
+  // Private->SqBufferPciAddr[0] = (NVME_SQ *)(UINTN)(Private->BufferPciAddr);
+  // Private->CqBuffer[0]        = (NVME_CQ *)(UINTN)(Private->Buffer + 1 * EFI_PAGE_SIZE);
+  // Private->CqBufferPciAddr[0] = (NVME_CQ *)(UINTN)(Private->BufferPciAddr + 1 * EFI_PAGE_SIZE);
+  // Private->SqBuffer[1]        = (NVME_SQ *)(UINTN)(Private->Buffer + 2 * EFI_PAGE_SIZE);
+  // Private->SqBufferPciAddr[1] = (NVME_SQ *)(UINTN)(Private->BufferPciAddr + 2 * EFI_PAGE_SIZE);
+  // Private->CqBuffer[1]        = (NVME_CQ *)(UINTN)(Private->Buffer + 3 * EFI_PAGE_SIZE);
+  // Private->CqBufferPciAddr[1] = (NVME_CQ *)(UINTN)(Private->BufferPciAddr + 3 * EFI_PAGE_SIZE);
+  // Private->SqBuffer[2]        = (NVME_SQ *)(UINTN)(Private->Buffer + 4 * EFI_PAGE_SIZE);
+  // Private->SqBufferPciAddr[2] = (NVME_SQ *)(UINTN)(Private->BufferPciAddr + 4 * EFI_PAGE_SIZE);
+  // Private->CqBuffer[2]        = (NVME_CQ *)(UINTN)(Private->Buffer + 5 * EFI_PAGE_SIZE);
+  // Private->CqBufferPciAddr[2] = (NVME_CQ *)(UINTN)(Private->BufferPciAddr + 5 * EFI_PAGE_SIZE);
 
-  // MU_CHANGE [END]
-
-  DEBUG ((DEBUG_INFO, "Private->Buffer = [%016X]\n", (UINT64)(UINTN)Private->Buffer));
-  DEBUG ((DEBUG_INFO, "Admin     Submission Queue size (Aqa.Asqs) = [%08X]\n", Aqa.Asqs));
-  DEBUG ((DEBUG_INFO, "Admin     Completion Queue size (Aqa.Acqs) = [%08X]\n", Aqa.Acqs));
-  DEBUG ((DEBUG_INFO, "Admin     Submission Queue (SqBuffer[0]) = [%016X]\n", Private->SqBuffer[0]));
-  DEBUG ((DEBUG_INFO, "Admin     Completion Queue (CqBuffer[0]) = [%016X]\n", Private->CqBuffer[0]));
-  DEBUG ((DEBUG_INFO, "Sync  I/O Submission Queue (SqBuffer[1]) = [%016X]\n", Private->SqBuffer[1]));
-  DEBUG ((DEBUG_INFO, "Sync  I/O Completion Queue (CqBuffer[1]) = [%016X]\n", Private->CqBuffer[1]));
-  DEBUG ((DEBUG_INFO, "Async I/O Submission Queue (SqBuffer[2]) = [%016X]\n", Private->SqBuffer[2]));
-  DEBUG ((DEBUG_INFO, "Async I/O Completion Queue (CqBuffer[2]) = [%016X]\n", Private->CqBuffer[2]));
+  // DEBUG ((DEBUG_INFO, "Admin     Submission Queue size (Aqa.Asqs) = [%08X]\n", Aqa.Asqs));
+  // DEBUG ((DEBUG_INFO, "Admin     Completion Queue size (Aqa.Acqs) = [%08X]\n", Aqa.Acqs));
+  // DEBUG ((DEBUG_INFO, "Admin     Submission Queue (SqBuffer[0]) = [%016X]\n", Private->SqBuffer[0]));
+  // DEBUG ((DEBUG_INFO, "Admin     Completion Queue (CqBuffer[0]) = [%016X]\n", Private->CqBuffer[0]));
+  // DEBUG ((DEBUG_INFO, "Sync  I/O Submission Queue (SqBuffer[1]) = [%016X]\n", Private->SqBuffer[1]));
+  // DEBUG ((DEBUG_INFO, "Sync  I/O Completion Queue (CqBuffer[1]) = [%016X]\n", Private->CqBuffer[1]));
+  // DEBUG ((DEBUG_INFO, "Async I/O Submission Queue (SqBuffer[2]) = [%016X]\n", Private->SqBuffer[2]));
+  // DEBUG ((DEBUG_INFO, "Async I/O Completion Queue (CqBuffer[2]) = [%016X]\n", Private->CqBuffer[2]));
 
   //
   // Program admin queue attributes.
@@ -920,22 +1302,246 @@ NvmeControllerInit (
   //
   // Program admin submission queue address.
   //
-  Status = WriteNvmeAdminSubmissionQueueBaseAddress (Private, &Asq);
-
-  if (EFI_ERROR (Status)) {
-    return Status;
-  }
+  // Status = WriteNvmeAdminSubmissionQueueBaseAddress (Private, &Asq);
 
   //
   // Program admin completion queue address.
   //
-  Status = WriteNvmeAdminCompletionQueueBaseAddress (Private, &Acq);
+  // Status = WriteNvmeAdminCompletionQueueBaseAddress (Private, &Acq);
+
+  Status = NvmeControllerInitAdminQueues (Private);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Status = NvmeEnableController (Private, Private->SqData[0].EntrySize, Private->CqData[0].EntrySize);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  // MU_CHANGE [END] - Allocate IO Queue Buffer
+
+  //
+  // Allocate buffer for Identify Controller data
+  //
+  if (Private->ControllerData == NULL) {
+    Private->ControllerData = (NVME_ADMIN_CONTROLLER_DATA *)AllocateZeroPool (sizeof (NVME_ADMIN_CONTROLLER_DATA));
+
+    if (Private->ControllerData == NULL) {
+      return EFI_OUT_OF_RESOURCES;
+    }
+  }
+
+  //
+  // Get current Identify Controller Data
+  //
+  Status = NvmeIdentifyController (Private, Private->ControllerData);
+
+  if (EFI_ERROR (Status)) {
+    FreePool (Private->ControllerData);
+    Private->ControllerData = NULL;
+    return EFI_NOT_FOUND;
+  }
+
+  //
+  // Dump NvmExpress Identify Controller Data
+  //
+  // Serial Number and Model Number are not null-terminated strings, but will be printed as ones.
+  // So here we add a null terminator to the end of their arrays.
+  CopyMem (Sn, Private->ControllerData->Sn, sizeof (Private->ControllerData->Sn));
+  Sn[20] = 0;
+  CopyMem (Mn, Private->ControllerData->Mn, sizeof (Private->ControllerData->Mn));
+  Mn[40] = 0;
+  DEBUG ((DEBUG_INFO, " == NVME IDENTIFY CONTROLLER DATA ==\n"));
+  DEBUG ((DEBUG_INFO, "    PCI VID   : 0x%x\n", Private->ControllerData->Vid));
+  DEBUG ((DEBUG_INFO, "    PCI SSVID : 0x%x\n", Private->ControllerData->Ssvid));
+  DEBUG ((DEBUG_INFO, "    SN        : %a\n", Sn));
+  DEBUG ((DEBUG_INFO, "    MN        : %a\n", Mn));
+  DEBUG ((DEBUG_INFO, "    FR        : 0x%x\n", *((UINT64 *)Private->ControllerData->Fr)));
+  DEBUG ((DEBUG_INFO, "    TNVMCAP (high 8-byte) : 0x%lx\n", *((UINT64 *)(Private->ControllerData->Tnvmcap + 8))));
+  DEBUG ((DEBUG_INFO, "    TNVMCAP (low 8-byte)  : 0x%lx\n", *((UINT64 *)Private->ControllerData->Tnvmcap)));
+  DEBUG ((DEBUG_INFO, "    RAB       : 0x%x\n", Private->ControllerData->Rab));
+  DEBUG ((DEBUG_INFO, "    IEEE      : 0x%x\n", *(UINT32 *)Private->ControllerData->Ieee_oui));
+  DEBUG ((DEBUG_INFO, "    AERL      : 0x%x\n", Private->ControllerData->Aerl));
+  DEBUG ((DEBUG_INFO, "    SQES      : 0x%x\n", Private->ControllerData->Sqes));
+  DEBUG ((DEBUG_INFO, "    CQES      : 0x%x\n", Private->ControllerData->Cqes));
+  DEBUG ((DEBUG_INFO, "    NN        : 0x%x\n", Private->ControllerData->Nn));
+
+  // MU_CHANGE [BEGIN] - Request Number of Queues from Controller
+  //
+  // Send Set Features Command to request the maximum number of data queues.
+  // The controller is free to allocate a different number of queues from the number requested.
+  // The number of queues allocated is returned and stored in the controller private data structure
+  // using the NumberOfIoQueuePairs field.
+  //
+  Status = NvmeSetFeaturesNumberOfQueues (Private, NVME_MAX_QUEUES - 1);
 
   if (EFI_ERROR (Status)) {
     return Status;
   }
 
-  Status = NvmeEnableController (Private);
+  // MU_CHANGE [END] - Request Number of Queues from Controller
+
+  // MU_CHANGE [BEGIN] - Allocate IO Queue Buffer
+  //
+  // Allocate Data Queues - note we are assuming the queue entry sizes are the same as the admin queue entry sizes for the sake of memory allocation.
+  // The identify controller data tells us in SQES and CQES what the controller's minimum and maximum queue entry sizes are. We haven't used this before since we
+  // use the spec-defined minimum queue entry sizes.
+  // We are also allocating based on the admin defined queue sizes in number of entries.
+  // Some scenarios may use different queue sizes, currently we only see the case where the driver needs IO queue sizes <= admin queue sizes. So this allocation should be sufficient.
+  // We may want to explore a more dynamic allocation in the future.
+  //
+  for (Index = 1; Index <= Private->NumberOfIoQueuePairs; Index++) {
+    Private->SqData[Index].NumberOfEntries = Private->SqData[0].NumberOfEntries;
+    Private->CqData[Index].NumberOfEntries = Private->CqData[0].NumberOfEntries;
+    Private->SqData[Index].EntrySize       = Private->SqData[0].EntrySize;
+    Private->CqData[Index].EntrySize       = Private->CqData[0].EntrySize;
+  }
+
+  // Using the first data queue size for the number of pages required for the data queues
+  IoQueuePairPageCount = NVME_SQ_SIZE_IN_PAGES (Private, 1) + NVME_CQ_SIZE_IN_PAGES (Private, 1);
+
+  Status = PciIo->AllocateBuffer (
+                    PciIo,
+                    AllocateAnyPages,
+                    EfiBootServicesData,
+                    IoQueuePairPageCount * Private->NumberOfIoQueuePairs,
+                    (VOID **)&Private->IoQueueBuffer,
+                    0
+                    );
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  // MS_HYP_CHANGE BEGIN
+  if (IsIsolated ()) {
+    Status = NvmExpressMakeAddressRangeShared (
+               &Private->IoQueueVisibilityContext,
+               Private->Buffer,
+               (UINT32)IoQueuePairPageCount * Private->NumberOfIoQueuePairs * EFI_PAGE_SIZE
+               );
+
+    if (EFI_ERROR (Status)) {
+      return Status;
+    }
+  }
+  // MS_HYP_CHANGE END
+
+  Bytes  = EFI_PAGES_TO_SIZE (IoQueuePairPageCount * Private->NumberOfIoQueuePairs);
+  Status = PciIo->Map (
+                    PciIo,
+                    EfiPciIoOperationBusMasterCommonBuffer,
+                    Private->IoQueueBuffer,
+                    &Bytes,
+                    &MappedAddr,
+                    &Private->IoQueueMapping
+                    );
+
+  if (EFI_ERROR (Status) || (Bytes != EFI_PAGES_TO_SIZE (IoQueuePairPageCount * Private->NumberOfIoQueuePairs))) {
+    return EFI_DEVICE_ERROR;
+  }
+
+
+  // MS_HYP_CHANGE BEGIN
+  if (IsIsolated()) {
+    //
+    // Canonicalize  the VA.
+    //
+    Private->IoQueueBuffer = NvmExpressGetSharedVa(Private->IoQueueBuffer);
+  }
+  // MS_HYP_CHANGE END
+
+
+  Private->IoQueueBufferPciAddr = (UINT8 *)(UINTN)MappedAddr;
+
+  Status = NvmeControllerInitIoQueues (Private);
+  // MU_CHANGE [END] - Allocate IO Queue Buffer
+
+  return Status;
+}
+
+// MU_CHANGE [BEGIN] - Allocate IO Queue Buffer
+
+/**
+  Reset the Nvm Express controller.
+
+  @param[in] Private                 The pointer to the NVME_CONTROLLER_PRIVATE_DATA data structure.
+
+  @retval EFI_SUCCESS                The NVM Express Controller is reset successfully.
+  @retval Others                     A device error occurred while resetting the controller.
+
+**/
+EFI_STATUS
+NvmeControllerReset (
+  IN NVME_CONTROLLER_PRIVATE_DATA  *Private
+  )
+{
+  EFI_STATUS           Status;
+  EFI_PCI_IO_PROTOCOL  *PciIo;
+  UINT32               Index;
+  UINT16               VidDid[2];
+  UINT8                Sn[21];
+  UINT8                Mn[41];
+  NVME_AQA             Aqa;
+  UINT32               NdqpBeforeReset;
+
+  DEBUG ((DEBUG_INFO, "%a: Begin Controller Reset\n", __func__));
+
+  PciIo = Private->PciIo;
+
+  //
+  // Verify the controller is still accessible
+  //
+  Status = PciIo->Pci.Read (
+                        PciIo,
+                        EfiPciIoWidthUint16,
+                        PCI_VENDOR_ID_OFFSET,
+                        ARRAY_SIZE (VidDid),
+                        VidDid
+                        );
+  if (EFI_ERROR (Status)) {
+    ASSERT_EFI_ERROR (Status);
+    return EFI_DEVICE_ERROR;
+  }
+
+  if ((VidDid[0] == NVME_INVALID_VID_DID) || (VidDid[1] == NVME_INVALID_VID_DID)) {
+    return EFI_DEVICE_ERROR;
+  }
+
+  for (Index = 0; Index < NVME_MAX_QUEUES; Index++) {
+    Private->Cid[Index]        = 0;
+    Private->Pt[Index]         = 0;
+    Private->SqTdbl[Index].Sqt = 0;
+    Private->CqHdbl[Index].Cqh = 0;
+  }
+
+  Private->AsyncSqHead = 0;
+
+  Status = NvmeDisableController (Private);
+
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Status = ReadNvmeAdminQueueAttributes (Private, &Aqa);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  if ((Private->SqData[0].NumberOfEntries != Aqa.Asqs) || (Private->CqData[0].NumberOfEntries != Aqa.Acqs)) {
+    // By spec these values should not change between resets, so we'll fail out here.
+    DEBUG ((DEBUG_ERROR, "%a: Admin Submission Queue Size (Number of Entries) mismatch: %d != %d\n", __func__, Private->SqData[0].NumberOfEntries, Aqa.Asqs));
+    ASSERT (FALSE);
+    return EFI_DEVICE_ERROR;
+  }
+
+  Status = NvmeControllerInitAdminQueues (Private);
+
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Status = NvmeEnableController (Private, Private->SqData[0].EntrySize, Private->CqData[0].EntrySize);
   if (EFI_ERROR (Status)) {
     return Status;
   }
@@ -966,6 +1572,8 @@ NvmeControllerInit (
   // Dump NvmExpress Identify Controller Data
   //
   CopyMem (Sn, Private->ControllerData->Sn, sizeof (Private->ControllerData->Sn));
+  // Serial Number and Model Number are not null-terminated strings, but will be printed as ones.
+  // So here we add a null terminator to the end of their arrays.
   Sn[20] = 0;
   CopyMem (Mn, Private->ControllerData->Mn, sizeof (Private->ControllerData->Mn));
   Mn[40] = 0;
@@ -985,22 +1593,37 @@ NvmeControllerInit (
   DEBUG ((DEBUG_INFO, "    NN        : 0x%x\n", Private->ControllerData->Nn));
 
   //
-  // Create two I/O completion queues.
-  // One for blocking I/O, one for non-blocking I/O.
+  // Send Set Features Command to request the maximum number of data queues.
+  // The controller is free to allocate a different number of queues from the number requested.
+  // The number of queues allocated is returned and stored in the controller private data structure
+  // using the NumberOfIoQueuePairs field.
   //
-  Status = NvmeCreateIoCompletionQueue (Private);
+  NdqpBeforeReset = Private->NumberOfIoQueuePairs;
+  Status          = NvmeSetFeaturesNumberOfQueues (Private, NVME_MAX_QUEUES - 1);
   if (EFI_ERROR (Status)) {
     return Status;
   }
 
+  if (NdqpBeforeReset != Private->NumberOfIoQueuePairs) {
+    // This is a controller reset, so the number of data queues should not have changed.
+    // If the number of queues has changed, then the driver must be re-initialized.
+    DEBUG ((DEBUG_ERROR, "%a: Number of Data Queue Pairs mismatch: %d != %d\n", __func__, NdqpBeforeReset, Private->NumberOfIoQueuePairs));
+    ASSERT (FALSE);
+    return EFI_DEVICE_ERROR;
+  }
+
   //
-  // Create two I/O Submission queues.
-  // One for blocking I/O, one for non-blocking I/O.
+  // Create I/O completion queue(s).
   //
-  Status = NvmeCreateIoSubmissionQueue (Private);
+  Status = NvmeControllerInitIoQueues (Private);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
 
   return Status;
 }
+
+// MU_CHANGE [END] - Allocate IO Queue Buffer
 
 /**
  This routine is called to properly shutdown the Nvm Express controller per NVMe spec.

--- a/MsvmPkg/NvmExpressDxe/NvmExpressHci.c
+++ b/MsvmPkg/NvmExpressDxe/NvmExpressHci.c
@@ -1212,7 +1212,15 @@ NvmeControllerInit (
                                               (UINT32)AdminQueuePairPageCount * EFI_PAGE_SIZE
                                               );
 
-    if (EFI_ERROR(Status)) {
+    if (EFI_ERROR (Status)) {
+      EFI_STATUS FreeStatus = PciIo->FreeBuffer (PciIo, AdminQueuePairPageCount, Private->Buffer);
+
+      if (EFI_ERROR (FreeStatus)) {
+        DEBUG ((DEBUG_ERROR, "%a: FreeBuffer Admin Queue Buffer failed %r\n", __func__, FreeStatus));
+        ASSERT_EFI_ERROR (FreeStatus);
+      }
+
+      Private->Buffer = NULL;
       return Status;
     }
   }
@@ -1417,11 +1425,19 @@ NvmeControllerInit (
   if (IsIsolated ()) {
     Status = NvmExpressMakeAddressRangeShared (
                &Private->IoQueueVisibilityContext,
-               Private->Buffer,
+               Private->IoQueueBuffer,
                (UINT32)IoQueuePairPageCount * Private->NumberOfIoQueuePairs * EFI_PAGE_SIZE
                );
 
     if (EFI_ERROR (Status)) {
+      EFI_STATUS FreeStatus = PciIo->FreeBuffer (PciIo, IoQueuePairPageCount*Private->NumberOfIoQueuePairs, Private->IoQueueBuffer);
+
+      if (EFI_ERROR (FreeStatus)) {
+        DEBUG ((DEBUG_ERROR, "%a: FreeBuffer IoQueueBuffer failed %r\n", __func__, FreeStatus));
+        ASSERT_EFI_ERROR (FreeStatus);
+      }
+
+      Private->IoQueueBuffer = NULL;
       return Status;
     }
   }

--- a/MsvmPkg/NvmExpressDxe/NvmExpressHci.h
+++ b/MsvmPkg/NvmExpressDxe/NvmExpressHci.h
@@ -18,6 +18,24 @@
 //
 #define NVME_ASQ_BUF_OFFSET  EFI_PAGE_SIZE
 
+// MU_CHANGE [BEGIN] - Allocate IO Queue Buffer
+
+/**
+  Reset the Nvm Express controller.
+
+  @param[in] Private                 The pointer to the NVME_CONTROLLER_PRIVATE_DATA data structure.
+
+  @retval EFI_SUCCESS                The NVM Express Controller is reset successfully.
+  @retval Others                     A device error occurred while resetting the controller.
+
+**/
+EFI_STATUS
+NvmeControllerReset (
+  IN NVME_CONTROLLER_PRIVATE_DATA  *Private
+  );
+
+// MU_CHANGE [END] - Allocate IO Queue Buffer
+
 /**
   Initialize the Nvm Express controller.
 
@@ -65,5 +83,25 @@ NvmeIdentifyNamespace (
   IN UINT32                        NamespaceId,
   IN VOID                          *Buffer
   );
+
+// MU_CHANGE [BEGIN] - Allocate IO Queue Buffer
+
+/**
+  Read Nvm Express admin queue attributes register.
+
+  @param  Private          The pointer to the NVME_CONTROLLER_PRIVATE_DATA data structure.
+  @param  Aqa              The buffer used to store the content to be read from admin queue attributes register.
+
+  @return EFI_SUCCESS      Successfully read data from the admin queue attributes register.
+  @return EFI_DEVICE_ERROR Fail to read data from the admin queue attributes register.
+
+**/
+EFI_STATUS
+ReadNvmeAdminQueueAttributes (
+  IN  NVME_CONTROLLER_PRIVATE_DATA  *Private,
+  OUT NVME_AQA                      *Aqa
+  );
+
+// MU_CHANGE [END] - Allocate IO Queue Buffer
 
 #endif

--- a/MsvmPkg/NvmExpressDxe/NvmExpressPassthru.c
+++ b/MsvmPkg/NvmExpressDxe/NvmExpressPassthru.c
@@ -267,6 +267,7 @@ NvmeCreatePrpList (
                     );
 
   if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: allocate PrpList failed %r\n", __func__, Status));
     return NULL;
   }
 
@@ -279,6 +280,9 @@ NvmeCreatePrpList (
 
     if (EFI_ERROR(Status))
     {
+        DEBUG ((DEBUG_ERROR, "%a: share PrpList failed %r\n", __func__, Status));
+        PciIo->FreeBuffer (PciIo, *PrpListNo, *PrpListHost);
+        *PrpListHost = NULL;
         goto EXIT;
     }
   }
@@ -295,7 +299,7 @@ NvmeCreatePrpList (
                     );
 
   if (EFI_ERROR (Status) || (Bytes != EFI_PAGES_TO_SIZE (*PrpListNo))) {
-    DEBUG ((DEBUG_ERROR, "NvmeCreatePrpList: create PrpList failure!\n"));
+    DEBUG ((DEBUG_ERROR, "%a: map PrpList failed %r\n", __func__, Status));
     goto EXIT;
   }
 
@@ -365,7 +369,6 @@ NvmeCreatePrpList (
   return (VOID *)(UINTN)PrpListPhyAddr;
 
 EXIT:
-  PciIo->FreeBuffer (PciIo, *PrpListNo, *PrpListHost);
   return NULL;
 }
 
@@ -770,7 +773,9 @@ NvmExpressPassThru (
                              &MapData
                              );
         if (EFI_ERROR (Status) || (Packet->TransferLength != MapLength)) {
-          return EFI_OUT_OF_RESOURCES;
+          DEBUG ((DEBUG_ERROR, "%a: Map transfer buffer error - %r!\n", __func__, Status));
+          Status = EFI_OUT_OF_RESOURCES;
+          goto EXIT;
         }
 
       } // MS_HYP_CHANGE
@@ -872,12 +877,9 @@ NvmExpressPassThru (
                              &MapMeta
                              );
         if (EFI_ERROR (Status) || (Packet->MetadataLength != MapLength)) {
-          PciIo->Unmap (
-                   PciIo,
-                   MapData
-                   );
-
-          return EFI_OUT_OF_RESOURCES;
+          DEBUG ((DEBUG_ERROR, "%a: Map packet metadata buffer error - %r!\n", __func__, Status));
+          Status = EFI_OUT_OF_RESOURCES;
+          goto EXIT;
         }
       } // MS_HYP_CHANGE
       Sq->Mptr = PhyAddr;
@@ -1160,13 +1162,14 @@ EXIT:
              );
   }
 
-  if (Prp != NULL) {
+  if (PrpListHost != NULL) {
     // MS_HYP_CHANGE BEGIN
     if (IsIsolated()) {
       NvmExpressMakeAddressRangePrivate(&PrpListVisibilityContext, PrpListHost);
     }
     // MS_HYP_CHANGE END
     PciIo->FreeBuffer (PciIo, PrpListNo, PrpListHost);
+    PrpListHost = NULL;
   }
 
   if (TimerEvent != NULL) {

--- a/MsvmPkg/NvmExpressDxe/NvmExpressPassthru.c
+++ b/MsvmPkg/NvmExpressDxe/NvmExpressPassthru.c
@@ -645,7 +645,7 @@ NvmExpressPassThru (
     QueueSize = MIN (NVME_ASYNC_CSQ_SIZE, Private->Cap.Mqes) + 1;
   }
 
-  // MU_CHANGE [END]
+  // MU_CHANGE [END] - Support alternative hardware queue sizes in NVME driver
 
   if (Packet->QueueType == NVME_ADMIN_QUEUE) {
     QueueId = 0;
@@ -931,7 +931,7 @@ NvmExpressPassThru (
     }
   }
 
-  // MU_CHANGE [END]
+  // MU_CHANGE [END] - Support alternative hardware queue sizes in NVME driver
 
   Data   = ReadUnaligned32 ((UINT32 *)&Private->SqTdbl[QueueId]);
   Status = PciIo->Mem.Write (
@@ -1069,7 +1069,7 @@ NvmExpressPassThru (
     //
     // Reset the NVMe controller.
     //
-    Status = NvmeControllerInit (Private);
+    Status = NvmeControllerReset (Private); // MU_CHANGE - Allocate IO Queue Buffer
     if (!EFI_ERROR (Status)) {
       Status = AbortAsyncPassThruTasks (Private);
       if (!EFI_ERROR (Status)) {
@@ -1103,7 +1103,7 @@ NvmExpressPassThru (
     }
   }
 
-  // MU_CHANGE [END]
+  // MU_CHANGE [END] - Support alternative hardware queue sizes in NVME driver
 
   Data           = ReadUnaligned32 ((UINT32 *)&Private->CqHdbl[QueueId]);
   PreviousStatus = Status;

--- a/MsvmPkg/PlatformPei/AArch64/Mmu.c
+++ b/MsvmPkg/PlatformPei/AArch64/Mmu.c
@@ -20,6 +20,7 @@
 #include <Library/BaseLib.h>
 #include <Library/DebugLib.h>
 #include <Library/SafeIntLib.h>
+#include <Library/CrashLib.h>
 #include <BiosInterface.h>
 #include <Config.h>
 
@@ -421,6 +422,31 @@ ConfigureMmu(
         MaxAddress, lowMmioSize, highMmioBaseAddress, highMmioSize));
 
     //
+    // Validate that MMIO regions fit within the physical address space.
+    // The host may provide MMIO ranges that extend beyond the CPU's
+    // physical address width, which would cause page table entries for
+    // unmappable addresses.
+    //
+    {
+        UINT64 highMmioEnd;
+        if (RETURN_ERROR(SafeUint64Add(highMmioBaseAddress, highMmioSize, &highMmioEnd)))
+        {
+            DEBUG((DEBUG_ERROR,
+                "ConfigureMmu: High MMIO range overflow (base=0x%lx, size=0x%lx)\n",
+                highMmioBaseAddress, highMmioSize));
+            FAIL_FAST_UNEXPECTED_HOST_BEHAVIOR();
+        }
+
+        if (highMmioEnd > MaxAddress + 1)
+        {
+            DEBUG((DEBUG_ERROR,
+                "ConfigureMmu: High MMIO end 0x%lx exceeds physical address limit 0x%lx\n",
+                highMmioEnd, MaxAddress));
+            FAIL_FAST_UNEXPECTED_HOST_BEHAVIOR();
+        }
+    }
+
+    //
     // Fill table that drives the mmu setup functions.
     //
     // From zero to beginning of low MMIO gap.
@@ -460,18 +486,17 @@ ConfigureMmu(
     virtualMemoryTable[4].VirtualBase = virtualMemoryTable[4].PhysicalBase;
 
     //
-    // Validate that the final region does not underflow.
+    // Validate that the final region does not underflow. This should
+    // not happen given the MMIO validation above, but check defensively.
     //
     if (virtualMemoryTable[4].PhysicalBase > MaxAddress)
     {
         DEBUG((DEBUG_ERROR, "ConfigureMmu: PhysicalBase (0x%lx) > MaxAddress (0x%lx)\n",
             virtualMemoryTable[4].PhysicalBase, MaxAddress));
-        ASSERT(FALSE);
-        return EFI_INVALID_PARAMETER;
+        FAIL_FAST_UNEXPECTED_HOST_BEHAVIOR();
     }
 
     virtualMemoryTable[4].Length = (MaxAddress - virtualMemoryTable[4].PhysicalBase) + 1;
-
     virtualMemoryTable[4].Attributes = ARM_MEMORY_REGION_ATTRIBUTE_WRITE_BACK;
 
     virtualMemoryTable[5].PhysicalBase = 0;

--- a/MsvmPkg/VmbusDxe/VmbusChannel.c
+++ b/MsvmPkg/VmbusDxe/VmbusChannel.c
@@ -134,6 +134,7 @@ Return Value:
     gpadl->NumberOfPages = (UINT32)((UINTN)BufferLength >> EFI_PAGE_SHIFT);
     gpadl->GpadlHandle = 0;
     gpadl->Legacy = FALSE;
+    gpadl->ProtectionHandle = NULL;
     zeroPages = (Flags & EFI_VMBUS_PREPARE_GPADL_FLAG_ZERO_PAGES) != 0;
 
     //
@@ -498,7 +499,8 @@ Return Value:
     // GPADL has been deleted.
     //
     if (IsIsolated() &&
-        !Gpadl->Legacy)
+        !Gpadl->Legacy &&
+        Gpadl->ProtectionHandle != NULL)
     {
         mHvIvm->MakeAddressRangeNotHostVisible(mHvIvm, Gpadl->ProtectionHandle);
     }

--- a/MsvmPkg/VmbusDxe/VmbusChannel.c
+++ b/MsvmPkg/VmbusDxe/VmbusChannel.c
@@ -502,7 +502,7 @@ Return Value:
         !Gpadl->Legacy &&
         Gpadl->ProtectionHandle != NULL)
     {
-        mHvIvm->MakeAddressRangeNotHostVisible(mHvIvm, Gpadl->ProtectionHandle);
+        mHvIvm->MakeAddressRangeNotHostVisible(mHvIvm, &Gpadl->ProtectionHandle);
     }
 
     //


### PR DESCRIPTION
NvmExpressDxe diverged significantly from closed source due to missing changes that never made it here. That fix has gone in.

Afterwards, cherry pick the remaining closed source changes on top. 