### PR TITLE
Merged PR 15471605: EfiHv: clear page memory attributes before free

### DIFF
--- a/MsvmPkg/EfiHvDxe/EfiHv.c
+++ b/MsvmPkg/EfiHvDxe/EfiHv.c
@@ -1926,6 +1926,18 @@ EfiHvDisconnectFromHypervisor (
 #if defined (MDE_CPU_X64)
     if (mHypercallPage != NULL)
     {
+        //
+        // Clear the EFI_MEMORY_RO attribute that was applied to this page
+        // after allocation before returning it to the page allocator, so a
+        // later allocator consumer does not get a still-read-only page.
+        //
+        status = mCpu->SetMemoryAttributes(mCpu, (EFI_PHYSICAL_ADDRESS)mHypercallPage, EFI_PAGE_SIZE, 0);
+        if (EFI_ERROR(status))
+        {
+            DEBUG((DEBUG_ERROR, "--- %a: failed to clear memory attributes - %r \n", __func__, status));
+            FAIL_FAST_UNEXPECTED_HOST_BEHAVIOR();
+        }
+
         FreePages(mHypercallPage, 1);
         mHypercallPage = NULL;
     }


### PR DESCRIPTION
When EfiHv needs to make a hypercall page, it marks it as RO. 

Unfortunately, we have been freeing this page back to DXE Core's allocator without clearing the RO bits. This results in rare occasions where we hit a race condition: DXE core may try to allocate one of these pages, and a subsequent write will trigger a page fault in the guest. 

Because we have no memory protections by default for non-isolated or non-TVMs, we have no guards against this.

This PR fixes that by ensuring we clear the RO bits before we free the page in EfiHv.

----
#### AI description  (iteration 1)
#### PR Classification
Bug fix to prevent guest triple-faults by clearing memory attributes before freeing the hypercall page.

#### PR Summary
Fixes a critical issue where read-only memory attributes persisted on freed pages, causing page faults when those pages were later reallocated for pool allocations with write operations.

- `EfiHvDxe/EfiHv.c`: Added explicit clearing of hardware memory attributes (EFI_MEMORY_RO) on the hypercall page before freeing it using `SetMemoryAttributes` with Attributes=0 to restore RW=1/NX=0, preventing the page allocator from handing out still-RO pages that would triple-fault on first write <!-- GitOpsUserAgent=GitOps.Apps.Server.pullrequestcopilot -->


Related work items: #62101222