### PR TITLE
Add PciResourcesPreAssigned config flag to skip PCI bus enumeration

### DIFF
--- a/MsvmPkg/Include/BiosInterface.h
+++ b/MsvmPkg/Include/BiosInterface.h
@@ -791,7 +791,8 @@ typedef struct _UEFI_CONFIG_FLAGS
         UINT64 MtrrsInitializedAtLoad : 1;
         UINT64 HvSintEnabled : 1;  // Reserved; used by other codebase.
         UINT64 VmbusDisabled : 1;
-        UINT64 Reserved:33;
+        UINT64 PciResourcesPreAssigned : 1;
+        UINT64 Reserved:32;
     } Flags;
 } UEFI_CONFIG_FLAGS;
 

--- a/MsvmPkg/MsvmPkgAARCH64.dsc
+++ b/MsvmPkg/MsvmPkgAARCH64.dsc
@@ -537,6 +537,7 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdStatusCodeUseMemory|FALSE
   gEfiMdeModulePkgTokenSpaceGuid.PcdStatusCodeUseSerial|FALSE
   gEfiMdeModulePkgTokenSpaceGuid.PcdPlatformRecoverySupport|FALSE
+  gEfiMdeModulePkgTokenSpaceGuid.PcdPciDisableBusEnumeration|FALSE
 
   gEfiMdePkgTokenSpaceGuid.PcdPlatformBootTimeOut|0x0
 

--- a/MsvmPkg/MsvmPkgX64.dsc
+++ b/MsvmPkg/MsvmPkgX64.dsc
@@ -555,6 +555,7 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdStatusCodeUseMemory|FALSE
   gEfiMdeModulePkgTokenSpaceGuid.PcdStatusCodeUseSerial|FALSE
   gEfiMdeModulePkgTokenSpaceGuid.PcdPlatformRecoverySupport|FALSE
+  gEfiMdeModulePkgTokenSpaceGuid.PcdPciDisableBusEnumeration|FALSE
 
   gEfiMdePkgTokenSpaceGuid.PcdPlatformBootTimeOut|0x0
 

--- a/MsvmPkg/PlatformPei/Config.c
+++ b/MsvmPkg/PlatformPei/Config.c
@@ -945,6 +945,7 @@ ConfigSetUefiConfigFlags(
     PEI_FAIL_FAST_IF_FAILED(PcdSetBoolS(PcdTpmLocalityRegsEnabled, (UINT8) ConfigFlags->Flags.TpmLocalityRegsEnabled));
     PEI_FAIL_FAST_IF_FAILED(PcdSetBoolS(PcdMtrrsInitializedAtLoad, (UINT8) ConfigFlags->Flags.MtrrsInitializedAtLoad));
     PEI_FAIL_FAST_IF_FAILED(PcdSetBoolS(PcdVmbusEnabled, !ConfigFlags->Flags.VmbusDisabled));
+    PEI_FAIL_FAST_IF_FAILED(PcdSetBoolS(PcdPciDisableBusEnumeration, (UINT8) ConfigFlags->Flags.PciResourcesPreAssigned));
 
     //
     // If memory protections are enabled, configure the value into the HOB.

--- a/MsvmPkg/PlatformPei/PlatformPei.inf
+++ b/MsvmPkg/PlatformPei/PlatformPei.inf
@@ -83,6 +83,7 @@
 
 [Pcd]
     gEfiMdeModulePkgTokenSpaceGuid.PcdNvmeNamespaceFilterId
+    gEfiMdeModulePkgTokenSpaceGuid.PcdPciDisableBusEnumeration
     gEfiNetworkPkgTokenSpaceGuid.PcdDhcp6UidType
     gMsvmPkgTokenSpaceGuid.PcdFdBaseAddress
     gMsvmPkgTokenSpaceGuid.PcdFdSize


### PR DESCRIPTION
When the VMM has pre-assigned PCI bus numbers and BAR addresses, it sets the PciResourcesPreAssigned flag in UEFI_CONFIG_FLAGS. PlatformPei reads this flag and sets PcdPciDisableBusEnumeration to TRUE, causing PciBusDxe to use its PciEnumeratorLight() path which discovers devices and reads their existing BAR values without reallocating resources.

Also adds placeholder bits for HvSintEnabled (bit 30) and VmbusDisabled (bit 31) to keep the config flags layout in sync with other branches.