### PR TITLE
PciHostBridgeLib: Set ResourceAssigned when bus enumeration is disabled

### DIFF
--- a/MsvmPkg/Library/PciHostBridgeLib/PciHostBridgeLib.c
+++ b/MsvmPkg/Library/PciHostBridgeLib/PciHostBridgeLib.c
@@ -195,11 +195,12 @@ PciHostBridgeGetRootBridges (
                                                     EFI_PCI_HOST_BRIDGE_MEM64_DECODE;
 
         //
-        // ResourceAssigned = FALSE: PciHostBridgeDxe will go through the
-        // full PCI resource allocation protocol with PciBusDxe.  The ECAM
-        // ranges are reserved separately in the loop below.
+        // When PcdPciDisableBusEnumeration is TRUE, PciBusDxe uses the
+        // lightweight enumerator which requires pre-assigned resources.
+        // Setting ResourceAssigned = TRUE causes CreateRootBridge to mark
+        // apertures as ResAllocated so Configuration emits them.
         //
-        Bridges[BridgeCount].ResourceAssigned     = FALSE;
+        Bridges[BridgeCount].ResourceAssigned     = PcdGetBool(PcdPciDisableBusEnumeration);
 
         //
         // Bus aperture.

--- a/MsvmPkg/Library/PciHostBridgeLib/PciHostBridgeLib.inf
+++ b/MsvmPkg/Library/PciHostBridgeLib/PciHostBridgeLib.inf
@@ -33,6 +33,7 @@
 [Pcd]
   gMsvmPkgTokenSpaceGuid.PcdPcieBarAperturesPtr
   gMsvmPkgTokenSpaceGuid.PcdPcieBarAperturesSize
+  gEfiMdeModulePkgTokenSpaceGuid.PcdPciDisableBusEnumeration
 
 [Guids]
   gAcpiReplacementTableHobGuid


### PR DESCRIPTION
Missed a fix in #78--we need to set ResourceAssigned to TRUE so that the bridge is successfully enumerated. Without this, you cannot boot from PCIe when the VMM pre-assigns resources.