### PR TITLE
Merged PR 15215195: [Copilot] Harden VmbfsDxe against malicious host responses

### DIFF
--- a/MsvmPkg/VmbfsDxe/Vmbfs.c
+++ b/MsvmPkg/VmbfsDxe/Vmbfs.c
@@ -155,6 +155,8 @@ Return Value:
         goto Cleanup;
     }
 
+    ZeroMem(fileSystemInformation->PacketBuffer, VMBFS_MAXIMUM_MESSAGE_SIZE);
+
     status = gBS->AllocatePool(EfiBootServicesData, sizeof(*allocatedFileProtocol), (void**)&allocatedFileProtocol);
 
     if (EFI_ERROR(status))
@@ -219,10 +221,7 @@ Return Value:
     if (bytesRead != sizeof(*VersionResponseMessage) ||
         VersionResponseMessage->Header.Type != VmbfsMessageTypeVersionResponse)
     {
-
-        VMBFS_BAD_HOST;
-        status = EFI_DEVICE_ERROR;
-        goto Cleanup;
+        FAIL_FAST_UNEXPECTED_HOST_BEHAVIOR();
     }
 
     if (VersionResponseMessage->Status != VmbfsVersionSupported)

--- a/MsvmPkg/VmbfsDxe/VmbfsDxe.inf
+++ b/MsvmPkg/VmbfsDxe/VmbfsDxe.inf
@@ -36,6 +36,7 @@
 [LibraryClasses]
   BaseLib
   BaseMemoryLib
+  CrashLib
   DebugLib
   EmclLib
   MemoryAllocationLib

--- a/MsvmPkg/VmbfsDxe/VmbfsEfi.h
+++ b/MsvmPkg/VmbfsDxe/VmbfsEfi.h
@@ -23,12 +23,11 @@
 #include <Library/UefiLib.h>
 #include <Library/MemoryAllocationLib.h>
 #include <Library/SynchronizationLib.h>
+#include <Library/CrashLib.h>
 #include <Library/DebugLib.h>
 #include <Library/PrintLib.h>
 #include <Library/EmclLib.h>
 
-
-#define VMBFS_BAD_HOST ASSERT(FALSE)
 
 #define GetPacketBuffer(fileInformation, Type) ((Type*)((fileInformation)->FileSystem->FileSystemInformation.PacketBuffer))
 #define GetPacketSize(fileInformation) (((fileInformation)->FileSystem->FileSystemInformation.PacketSize))

--- a/MsvmPkg/VmbfsDxe/VmbfsFile.c
+++ b/MsvmPkg/VmbfsDxe/VmbfsFile.c
@@ -85,8 +85,7 @@ Return Value:
 
     if (BufferLength > VMBFS_MAXIMUM_MESSAGE_SIZE)
     {
-        VMBFS_BAD_HOST;
-        BufferLength = MIN(BufferLength, VMBFS_MAXIMUM_MESSAGE_SIZE);
+        FAIL_FAST_UNEXPECTED_HOST_BEHAVIOR();
     }
 
     CopyMem(fileSystemInformation->PacketBuffer, Buffer, BufferLength);
@@ -381,10 +380,7 @@ Return Value:
     if (bytesRead != sizeof(*getFileInfoResponseMessage) ||
         getFileInfoResponseMessage->Header.Type != VmbfsMessageTypeGetFileInfoResponse)
     {
-
-        VMBFS_BAD_HOST;
-        status = EFI_DEVICE_ERROR;
-        goto Cleanup;
+        FAIL_FAST_UNEXPECTED_HOST_BEHAVIOR();
     }
 
     if (getFileInfoResponseMessage->Status == VmbfsFileNotFound)
@@ -591,9 +587,7 @@ Return Value:
     if (bytesReceived < sizeof(*readFileResponseMessage) ||
         readFileResponseMessage->Header.Type != VmbfsMessageTypeReadFileResponse)
     {
-        VMBFS_BAD_HOST;
-        status = EFI_DEVICE_ERROR;
-        goto Cleanup;
+        FAIL_FAST_UNEXPECTED_HOST_BEHAVIOR();
     }
 
     status = VmbfsErrorToEfiError(readFileResponseMessage->Status);
@@ -605,9 +599,7 @@ Return Value:
     bytesReceived -= sizeof(VMBFS_MESSAGE_READ_FILE_RESPONSE);
     if (bytesReceived > bytesRequested)
     {
-        VMBFS_BAD_HOST;
-        status = EFI_DEVICE_ERROR;
-        goto Cleanup;
+        FAIL_FAST_UNEXPECTED_HOST_BEHAVIOR();
     }
 
     CopyMem((UINT8*)Buffer,
@@ -702,9 +694,7 @@ Return Value:
     if (bytesReceived < sizeof(*readFileResponseMessage) ||
         readFileResponseMessage->Header.Type != VmbfsMessageTypeReadFileRdmaResponse)
     {
-        VMBFS_BAD_HOST;
-        status = EFI_DEVICE_ERROR;
-        goto Cleanup;
+        FAIL_FAST_UNEXPECTED_HOST_BEHAVIOR();
     }
 
     status = VmbfsErrorToEfiError(readFileResponseMessage->Status);
@@ -715,9 +705,7 @@ Return Value:
 
     if (readFileResponseMessage->ByteCount > bytesRequested)
     {
-        VMBFS_BAD_HOST;
-        status = EFI_DEVICE_ERROR;
-        goto Cleanup;
+        FAIL_FAST_UNEXPECTED_HOST_BEHAVIOR();
     }
 
     *BytesRead = readFileResponseMessage->ByteCount;


### PR DESCRIPTION
[Copilot] Harden VmbfsDxe against malicious host responses

Remove VMBFS_BAD_HOST macro (was ASSERT(FALSE), no-op in release) and replace all call sites with FAIL_FAST_UNEXPECTED_HOST_BEHAVIOR(). Remove dead code after each FAIL_FAST (status assignments, goto Cleanup, buffer clamping) since FAIL_FAST terminates the system.

Hardened checks: version response size/type, file info response size/type, read payload response size/type, response byte count exceeding request, and oversized receive callback packets.

----
Security hardening: enforce fail-fast behavior and stricter validation to defend VmbfsDxe against malicious/unexpected host responses.

Strengthens VmbfsDxe’s handling of incorrect/hostile VMBFS messages by replacing recoverable error paths with fail-fast crashes and tightening message buffer handling.
- `MsvmPkg/VmbfsDxe/VmbfsEfi.h`: remove `VMBFS_BAD_HOST` macro and add `CrashLib` include to support fail-fast behavior.
- `MsvmPkg/VmbfsDxe/Vmbfs.c`: fail fast on invalid version response messages; zero-initialize the packet buffer before use.
- `MsvmPkg/VmbfsDxe/VmbfsFile.c`: replace multiple “bad host” error/cleanup paths with `FAIL_FAST_UNEXPECTED_HOST_BEHAVIOR()` for malformed responses, size mismatches, and oversize buffer lengths.
- `MsvmPkg/VmbfsDxe/VmbfsDxe.inf`: add `CrashLib` dependency to wire in the new fail-fast mechanism. <!-- GitOpsUserAgent=GitOps.Apps.Server.pullrequestcopilot -->

Related work items: #61642528