### PR TITLE
CI: use windows-2022 for GitHub runner

### DIFF
--- a/.github/workflows/Platform-Build.yml
+++ b/.github/workflows/Platform-Build.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     strategy:
       matrix:


### PR DESCRIPTION
GitHub moved to VS2026. We only build on VS2022 right now. Use windows-2022, which still has VS2022.