### PR TITLE
MsvmPkg/PlatformPei: Skip DMA pinning detection when Hv is disabled

### DIFF
--- a/MsvmPkg/PlatformPei/Hv.c
+++ b/MsvmPkg/PlatformPei/Hv.c
@@ -13,6 +13,7 @@
 #include <Hv/HvGuestCpuid.h>
 #include <Library/DebugLib.h>
 #include <Library/CrashDumpAgentLib.h>
+#include <Library/PcdLib.h>
 #include <Library/HvHypercallLib.h>
 #include "MsCpuid.h"
 #include "StaticAssert1.h"
@@ -174,6 +175,17 @@ Return Value:
 --*/
 {
     EFI_STATUS status;
+
+    //
+    // When Hyper-V is disabled (e.g. the loader reported a Generic platform via
+    // the SEC platform type PPI) no hypervisor is present to service hypercalls.
+    // Issuing one here during PEI - before the exception vectors are installed -
+    // hard hangs the system, so skip the detection entirely.
+    //
+    if (!PcdGetBool(PcdHvEnabled))
+    {
+        return;
+    }
 
 #if defined(MDE_CPU_X64)
 


### PR DESCRIPTION
HvDetectDmaPinningRequired() issues an AArch64 hypercall (AsmGetVpRegister(HvRegisterFeaturesInfo)) unconditionally during PEI. The X64 path guards this with a HypervisorPresent CPUID check, but the AArch64 path had no equivalent guard.

On a Generic (no-Hyper-V) platform there is no hypervisor to service the hvc. Issuing it in PEI - before the exception vectors are installed - causes an intercept loop that hard hangs the machine.

This is a regression: the no-Hv support (PcdHvEnabled, gated via the SEC platform type PPI) predates HvDetectDmaPinningRequired, which was added later by the IommuDxe pinning work without accounting for the no-Hv path.

Guard the whole detection on PcdHvEnabled so no hypercall is issued when Hyper-V is disabled. X64 is unaffected (PcdHvEnabled defaults TRUE and is never cleared there).