### PR TITLE
MsvmPkg: fix CLANGPDB X64 boot hang from misaligned PEI

### DIFF
--- a/MsvmPkg/MsvmPkgAARCH64.fdf
+++ b/MsvmPkg/MsvmPkgAARCH64.fdf
@@ -313,7 +313,7 @@ FILE FREEFORM = PCD(gMsvmPkgTokenSpaceGuid.PcdBootFailIndicatorFile) {
 
 [Rule.Common.PEI_CORE]
   FILE PEI_CORE = $(NAMED_GUID) {
-    PE32     PE32   Align=4K    $(INF_OUTPUT)/$(MODULE_NAME).efi
+    PE32     PE32   Align=Auto    $(INF_OUTPUT)/$(MODULE_NAME).efi
     UI       STRING ="$(MODULE_NAME)" Optional
     VERSION  STRING ="$(INF_VERSION)" Optional BUILD_NUM=$(BUILD_NUMBER)
   }
@@ -321,7 +321,7 @@ FILE FREEFORM = PCD(gMsvmPkgTokenSpaceGuid.PcdBootFailIndicatorFile) {
 [Rule.Common.PEIM]
   FILE PEIM = $(NAMED_GUID) {
      PEI_DEPEX PEI_DEPEX Optional        $(INF_OUTPUT)/$(MODULE_NAME).depex
-     PE32      PE32   Align=4K          $(INF_OUTPUT)/$(MODULE_NAME).efi
+     PE32      PE32   Align=Auto          $(INF_OUTPUT)/$(MODULE_NAME).efi
      UI       STRING="$(MODULE_NAME)" Optional
      VERSION  STRING="$(INF_VERSION)" Optional BUILD_NUM=$(BUILD_NUMBER)
   }

--- a/MsvmPkg/MsvmPkgX64.fdf
+++ b/MsvmPkg/MsvmPkgX64.fdf
@@ -367,7 +367,7 @@ FILE FREEFORM = PCD(gMsvmPkgTokenSpaceGuid.PcdBootFailIndicatorFile) {
 
 [Rule.Common.PEI_CORE]
   FILE PEI_CORE = $(NAMED_GUID) {
-    PE32     PE32   Align=32    $(INF_OUTPUT)/$(MODULE_NAME).efi
+    PE32     PE32   Align=Auto    $(INF_OUTPUT)/$(MODULE_NAME).efi
     UI       STRING ="$(MODULE_NAME)" Optional
     VERSION  STRING ="$(INF_VERSION)" Optional BUILD_NUM=$(BUILD_NUMBER)
   }
@@ -375,7 +375,7 @@ FILE FREEFORM = PCD(gMsvmPkgTokenSpaceGuid.PcdBootFailIndicatorFile) {
 [Rule.Common.PEIM]
   FILE PEIM = $(NAMED_GUID) {
      PEI_DEPEX PEI_DEPEX Optional        $(INF_OUTPUT)/$(MODULE_NAME).depex
-     PE32      PE32   Align=32           $(INF_OUTPUT)/$(MODULE_NAME).efi
+     PE32      PE32   Align=Auto           $(INF_OUTPUT)/$(MODULE_NAME).efi
      UI       STRING="$(MODULE_NAME)" Optional
      VERSION  STRING="$(INF_VERSION)" Optional BUILD_NUM=$(BUILD_NUMBER)
   }
@@ -391,7 +391,7 @@ FILE FREEFORM = PCD(gMsvmPkgTokenSpaceGuid.PcdBootFailIndicatorFile) {
 [Rule.Common.PEIM.PLATFORM_PEI]
   FILE PEIM = $(NAMED_GUID) {
      PEI_DEPEX PEI_DEPEX Optional        $(INF_OUTPUT)/$(MODULE_NAME).depex
-     PE32      PE32   Align=32           $(INF_OUTPUT)/$(MODULE_NAME).efi
+     PE32      PE32   Align=Auto           $(INF_OUTPUT)/$(MODULE_NAME).efi
      UI       STRING="$(MODULE_NAME)" Optional
      VERSION  STRING="$(INF_VERSION)" Optional BUILD_NUM=$(BUILD_NUMBER)
   }


### PR DESCRIPTION
The CLANGPDB X64 firmware hangs in early PEI: PeiCore dispatches its first PEIMs (the apriori PcdPeim and EfiDiagnosticsPei), fails to load them, and then never runs PlatformPei to install permanent memory, so it asserts on PeiMemoryInstalled == TRUE at PeiMain.c(560). Because no exception handlers are installed this early, the failure surfaces only as a silently wedged VP.

The root cause is an FV packing mismatch. The X64 FDF packed PEI_CORE and PEIM files with a fixed 32-byte alignment (Align=32), a legacy idiom that assumes XIP PEI modules have small section alignment. But the platform DSC forces 4K section alignment on all PEI-phase modules for page protection, and x64 PE images default to 4K section alignment regardless. When a module's section alignment exceeds the FV packing alignment, PeiCore's image loader cannot execute it in place, and in pre-memory PEI it cannot shadow it to RAM either, so dispatch fails. CLANGPDB exposes this because it honors the 4K section alignment, leaving every dispatched PEIM at a 32-byte-aligned flash address that PeiCore rejects.

Switch the PEI_CORE, PEIM, and PLATFORM_PEI rules to Align=Auto so GenFds pads each file to the actual section alignment reported by its PE header, which is the standard EDK2 idiom (matching upstream OvmfPkg). This makes the packing adapt to whatever alignment the toolchain emits instead of assuming 32 bytes.

Apply the same Align=Auto change to the AARCH64 FDF for consistency. That FDF already used a hardcoded Align=4K that happens to match its 4K PEI section alignment, so Auto resolves to the same value and placement is unchanged; it is switched purely to keep both FDFs on the same, self-adjusting rule.