### PR TITLE
Merged PR 16154870: MsvmPkg: Advertise emulated IPMI/SEL BMC to the guest (SMBIOS Type 38 + ACPI IPI0001), gated on PcdIpmiEnabled

### DIFF
--- a/MsvmPkg/AcpiPlatformDxe/AcpiPlatformDxe.inf
+++ b/MsvmPkg/AcpiPlatformDxe/AcpiPlatformDxe.inf
@@ -86,6 +86,7 @@
     gMsvmPkgTokenSpaceGuid.PcdVirtualBatteryEnabled             ## CONSUMES
     gMsvmPkgTokenSpaceGuid.PcdVmbusEnabled                      ## CONSUMES
     gMsvmPkgTokenSpaceGuid.PcdWatchdogEnabled                   ## CONSUMES
+    gMsvmPkgTokenSpaceGuid.PcdIpmiEnabled                       ## CONSUMES
 
 [Pcd.X64]
     gMsvmPkgTokenSpaceGuid.PcdAcpiMadtMpMailBoxAddress          ## PRODUCES

--- a/MsvmPkg/AcpiPlatformDxe/Dsdt.c
+++ b/MsvmPkg/AcpiPlatformDxe/Dsdt.c
@@ -34,6 +34,7 @@ typedef struct _DSDT_AML_DATA
     UINT8  CxlMemoryEnabled;
     UINT16 NvdimmCount;
     UINT8  VmbusEnabled;
+    UINT8  IpmiEnabled;
 } DSDT_AML_DATA;
 
 typedef struct _DSDT_AML_DESCRIPTOR
@@ -140,6 +141,7 @@ Return Value:
     data->CxlMemoryEnabled = PcdGetBool(PcdCxlMemoryEnabled);
     data->NvdimmCount = PcdGet16(PcdNvdimmCount);
     data->VmbusEnabled = PcdGetBool(PcdVmbusEnabled);
+    data->IpmiEnabled = PcdGetBool(PcdIpmiEnabled);
 
     DEBUG((DEBUG_VERBOSE, "--- %a: Mmio1Start               0x%lx\n", __func__, data->Mmio1Start));
     DEBUG((DEBUG_VERBOSE, "--- %a: Mmio1Length              0x%lx\n", __func__, data->Mmio1Length));
@@ -154,6 +156,7 @@ Return Value:
     DEBUG((DEBUG_VERBOSE, "--- %a: ProcIdleEnabled          0x%x\n", __func__, data->ProcIdleEnabled));
     DEBUG((DEBUG_VERBOSE, "--- %a: CxlMemoryEnabled         0x%x\n", __func__, data->CxlMemoryEnabled));
     DEBUG((DEBUG_VERBOSE, "--- %a: NvdimmCount              0x%x\n", __func__, data->NvdimmCount));
+    DEBUG((DEBUG_VERBOSE, "--- %a: IpmiEnabled              0x%x\n", __func__, data->IpmiEnabled));
 
     //
     // Allocate space for the NVDIMM IO Buffer if VPMEM is enabled.

--- a/MsvmPkg/AcpiTables/Dsdt.asl
+++ b/MsvmPkg/AcpiTables/Dsdt.asl
@@ -64,6 +64,7 @@ DefinitionBlock (
         CCFG,8,         // CXL memory support enabled/disabled
         NCNT,16,        // NVDIMM count
         VCFG,8,         // VMBus enabled/disabled
+        ICFG,8,         // IPMI (emulated BMC) enabled/disabled
     }
 
     // Supported machine sleep states =========================================
@@ -313,6 +314,38 @@ DefinitionBlock (
 #endif
 
     }
+
+    // IPMI KCS BMC ===========================================================
+    // Emulated IPMI BMC exposed over the KCS system interface at I/O ports
+    // 0x0CA2 (data) / 0x0CA3 (status/command). The device is only declared when
+    // the host enabled the emulated IPMI device (ICFG). Advertising the ACPI
+    // IPI0001 device lets the Windows IPMI driver (ipmidrv) discover and bind to
+    // the KCS interface; Linux discovers the same BMC via SMBIOS Type 38.
+    //
+    // This is x64-only: the emulated BMC is reachable exclusively through legacy
+    // port-mapped I/O (0x0CA2/0x0CA3), and AArch64 has no I/O port space, so the
+    // IO() resource descriptor below is meaningful only on x86.
+
+#if defined(_DSDT_INTEL_)
+
+    If(LGreater(ICFG, 0))
+    {
+        Device(\_SB.IPMI)
+        {
+            Name(_HID, "IPI0001")           // ACPI IPMI device
+            Name(_STR, Unicode("IPMI KCS Device"))
+            Name(_UID, 0x0)
+            Name(_IFT, 0x1)                 // Interface type: 1 = KCS
+            Name(_SRV, 0x0200)              // IPMI specification revision 2.0
+            Name(_CRS, ResourceTemplate()
+            {
+                // KCS data register (0x0CA2) and status/command register (0x0CA3).
+                IO(Decode16, 0x0CA2, 0x0CA2, 0x01, 0x02)
+            })
+        }
+    }
+
+#endif
 
     // VMBus ==================================================================
 

--- a/MsvmPkg/Include/BiosInterface.h
+++ b/MsvmPkg/Include/BiosInterface.h
@@ -793,7 +793,8 @@ typedef struct _UEFI_CONFIG_FLAGS
         UINT64 VmbusDisabled : 1;
         UINT64 PciResourcesPreAssigned : 1;
         UINT64 ForceDmaBounceEnabled : 1;
-        UINT64 Reserved:31;
+        UINT64 IpmiEnabled : 1;          // Expose the emulated IPMI BMC via SMBIOS Type 38.
+        UINT64 Reserved:30;
     } Flags;
 } UEFI_CONFIG_FLAGS;
 

--- a/MsvmPkg/MsvmPkg.dec
+++ b/MsvmPkg/MsvmPkg.dec
@@ -307,6 +307,7 @@
   gMsvmPkgTokenSpaceGuid.PcdVmbusEnabled|TRUE|BOOLEAN|0x6068
   gMsvmPkgTokenSpaceGuid.PcdHvEnabled|TRUE|BOOLEAN|0x6069
   gMsvmPkgTokenSpaceGuid.PcdForceDmaBounceEnabled|FALSE|BOOLEAN|0x6076
+  gMsvmPkgTokenSpaceGuid.PcdIpmiEnabled|FALSE|BOOLEAN|0x6078
 
   # UEFI_CONFIG_PROCESSOR_INFORMATION
   gMsvmPkgTokenSpaceGuid.PcdProcessorCount|0x0|UINT32|0x6032

--- a/MsvmPkg/MsvmPkgX64.dsc
+++ b/MsvmPkg/MsvmPkgX64.dsc
@@ -734,6 +734,7 @@
   gMsvmPkgTokenSpaceGuid.PcdVmbusEnabled|TRUE
   gMsvmPkgTokenSpaceGuid.PcdHvEnabled|TRUE
   gMsvmPkgTokenSpaceGuid.PcdForceDmaBounceEnabled|FALSE
+  gMsvmPkgTokenSpaceGuid.PcdIpmiEnabled|FALSE
 
   # UEFI_CONFIG_PROCESSOR_INFORMATION
   gMsvmPkgTokenSpaceGuid.PcdProcessorCount|0x0

--- a/MsvmPkg/PlatformPei/Config.c
+++ b/MsvmPkg/PlatformPei/Config.c
@@ -959,6 +959,7 @@ ConfigSetUefiConfigFlags(
 
     PEI_FAIL_FAST_IF_FAILED(PcdSetBoolS(PcdPciDisableBusEnumeration, (UINT8) ConfigFlags->Flags.PciResourcesPreAssigned));
     PEI_FAIL_FAST_IF_FAILED(PcdSetBoolS(PcdForceDmaBounceEnabled, (UINT8) ConfigFlags->Flags.ForceDmaBounceEnabled));
+    PEI_FAIL_FAST_IF_FAILED(PcdSetBoolS(PcdIpmiEnabled, (UINT8) ConfigFlags->Flags.IpmiEnabled));
 
     //
     // If memory protections are enabled, configure the value into the HOB.

--- a/MsvmPkg/PlatformPei/PlatformPei.inf
+++ b/MsvmPkg/PlatformPei/PlatformPei.inf
@@ -185,6 +185,7 @@
     gMsvmPkgTokenSpaceGuid.PcdMtrrsInitializedAtLoad
     gMsvmPkgTokenSpaceGuid.PcdVmbusEnabled
     gMsvmPkgTokenSpaceGuid.PcdHvEnabled
+    gMsvmPkgTokenSpaceGuid.PcdIpmiEnabled
     gMsvmPkgTokenSpaceGuid.PcdForceDmaBounceEnabled
     gMsvmPkgTokenSpaceGuid.PcdPcieBarAperturesPtr
     gMsvmPkgTokenSpaceGuid.PcdPcieBarAperturesSize

--- a/MsvmPkg/SmbiosPlatformDxe/SmbiosPlatform.c
+++ b/MsvmPkg/SmbiosPlatformDxe/SmbiosPlatform.c
@@ -1914,6 +1914,97 @@ Return Value:
 }
 
 
+#if defined(MDE_CPU_X64)
+
+VOID
+AddIpmiDeviceInformation(
+    IN  EFI_SMBIOS_PROTOCOL* Smbios
+    )
+/*++
+
+Routine Description:
+
+    Adds the IPMI Device Information structure (type 38) to the SMBIOS table,
+    advertising the emulated BMC's KCS system interface so the guest OS
+    (Linux ipmi_si / the Windows IPMI driver) can discover and bind to it.
+
+    Only added when the host enables the emulated IPMI device (PcdIpmiEnabled),
+    which is driven by the platform diagnostic-logging setting. The emulated BMC
+    exposes the KCS data/status registers at I/O ports 0xCA2 (data) and 0xCA3
+    (status/command).
+
+    This is x64-only: the KCS registers are reachable exclusively through legacy
+    port-mapped I/O, and the Type 38 base address below is encoded as I/O space
+    (bit 0 = 1). AArch64 has no I/O port space, so the structure is not emitted
+    there.
+
+Arguments:
+
+    Smbios - The DXE Smbios protocol.
+
+Return Value:
+
+    n/a
+
+--*/
+{
+    //
+    // Only advertise the BMC when the emulated IPMI device is enabled by the host.
+    //
+    if (!PcdGetBool(PcdIpmiEnabled))
+    {
+        return;
+    }
+
+    //
+    // Initialized structure with terminator bytes (no strings).
+    //
+    static struct
+    {
+        SMBIOS_TABLE_TYPE38 Formatted;
+        CHAR8 Unformed[2];
+    } ipmiDeviceInformation =
+
+    {
+        {
+            STANDARD_HEADER(SMBIOS_TABLE_TYPE38, EFI_SMBIOS_TYPE_IPMI_DEVICE_INFORMATION),
+            IPMIDeviceInfoInterfaceTypeKCS, // Interface Type - Keyboard Controller Style
+            0x20,   // IPMI Specification Revision (BCD): 2.0
+            0x20,   // I2C Slave Address of the BMC (IPMB address; unused for KCS discovery)
+            0xFF,   // NV Storage Device Address - not a separate device
+            //
+            // Base Address: I/O port 0xCA2. Per SMBIOS v3.1 section 7.39, the
+            // least-significant bit indicates the address space (1 = I/O), so the
+            // encoded value is 0xCA2 | 1 = 0xCA3. Consumers mask bit 0 to recover
+            // the port (0xCA2).
+            //
+            0x0000000000000CA3ULL,
+            //
+            // Base Address Modifier / Interrupt Info:
+            //   bits 7:6 = 00b -> registers on successive byte boundaries
+            //              (0xCA2 = data, 0xCA3 = status/command)
+            //   bit 3    = 0b  -> interrupt info not specified
+            //   remaining bits 0 -> KCS is polled (no interrupt)
+            //
+            0x00,
+            0x00    // Interrupt Number - none
+        },
+        {
+            0, // terminator bytes
+            0
+        }
+    };
+
+    //
+    // Add the structure to the SMBIOS table. Error is not fatal and ignored.
+    //
+    (VOID)AddStructure(Smbios, &ipmiDeviceInformation, NULL, NULL);
+}
+
+#endif
+
+
+
 VOID
 AddAllStructures(
     IN  EFI_SMBIOS_PROTOCOL* Smbios
@@ -1946,6 +2037,9 @@ Return Value:
     AddOEMStrings(Smbios);
     AddMemoryStructures(Smbios);
     AddSystemBootInformation(Smbios);
+#if defined(MDE_CPU_X64)
+    AddIpmiDeviceInformation(Smbios);
+#endif
 }
 
 

--- a/MsvmPkg/SmbiosPlatformDxe/SmbiosPlatformDxe.inf
+++ b/MsvmPkg/SmbiosPlatformDxe/SmbiosPlatformDxe.inf
@@ -98,6 +98,7 @@
     gMsvmPkgTokenSpaceGuid.PcdProcessorCount                    ## CONSUMES
     gMsvmPkgTokenSpaceGuid.PcdProcessorsPerVirtualSocket        ## CONSUMES
     gMsvmPkgTokenSpaceGuid.PcdThreadsPerProcessor               ## CONSUMES
+    gMsvmPkgTokenSpaceGuid.PcdIpmiEnabled                       ## CONSUMES
 
 [Depex]
     gEfiSmbiosProtocolGuid


### PR DESCRIPTION
Advertise the emulated IPMI BMC (implemented in the HCL paravisor, KCS interface at I/O ports `0xCA2`/`0xCA3`) to the guest OS so it can discover and bind to it. Two discovery mechanisms are added, both gated on a new `PcdIpmiEnabled` that the host sets via `UEFI_CONFIG_FLAGS.IpmiEnabled`. Default is **off** (`FALSE`) — no behavior change unless the host enables IPMI.

The BMC/SEL emulator lives in the LegacyHCL/OpenHCL paravisor; the guest records System Event Log (SEL) entries over KCS, which the host logs for UVM diagnosability. The two guest OSes discover an IPMI BMC differently:
- **Linux** (`ipmi_si`) reads **SMBIOS Type 38** (IPMI Device Information).
- **Windows** (`ipmidrv`) binds to an **ACPI** node `ACPI\IPI0001` created from a DSDT namespace device.

Firmware previously advertised neither, so neither guest OS auto-bound its IPMI driver.

1. **SMBIOS Type 38** — emit an IPMI Device Information structure (Interface Type = KCS `0x01`, Base Address `0xCA2` I/O space, Spec Rev 2.0) from `SmbiosPlatformDxe`, gated on `PcdIpmiEnabled`.
2. **ACPI IPI0001** — add a DSDT device `\_SB.IPMI` (`_HID "IPI0001"`, `_IFT` = KCS, `_SRV` = IPMI 2.0, `_CRS` = I/O `0xCA2`–`0xCA3`), conditionally declared via a runtime `ICFG` flag in the DSDT data blob, mirroring the existing VMBus `VCFG` pattern.

`UEFI_CONFIG_FLAGS.IpmiEnabled` (host) → `PlatformPei/Config.c` → `PcdSetBoolS(PcdIpmiEnabled)` → consumed by `SmbiosPlatformDxe` (Type 38) and `AcpiPlatformDxe` (DSDT `ICFG`).

- `MsvmPkg/Include/BiosInterface.h` — add `IpmiEnabled : 1` to `UEFI_CONFIG_FLAGS`.
- `MsvmPkg/MsvmPkg.dec`, `MsvmPkg/MsvmPkgX64.dsc` — declare `PcdIpmiEnabled` (default `FALSE`).
- `MsvmPkg/PlatformPei/Config.c`, `PlatformPei/PlatformPei.inf` — map the config flag → PCD (PEI sets it).
- `MsvmPkg/SmbiosPlatformDxe/SmbiosPlatform.c`, `SmbiosPlatformDxe.inf` — `AddIpmiDeviceInformation()` (Type 38); consumes PCD.
- `MsvmPkg/AcpiTables/Dsdt.asl` — `ICFG` field + `If(ICFG>0)` IPI0001 device block.
- `MsvmPkg/AcpiPlatformDxe/Dsdt.c`, `AcpiPlatformDxe.inf` — populate `IpmiEnabled` in the DSDT data blob from the PCD.

- `MsvmX64` builds clean (`stuart_build`).
- End-to-end on a nested VM with IPMI enabled: guest shows `ACPI\IPI0001\0` ("Microsoft Generic IPMI Compliant Device"), `ipmidrv` Running, `Microsoft_IPMI` WMI present; SMBIOS scan shows Type 38. Get Device ID and Add SEL Entry succeed over KCS, and SEL entries reach the host ETW provider.
- With `PcdIpmiEnabled=FALSE` (default): neither structure is emitted — no behavior change.