### PR TITLE
MsvmPkg: add DisableSha1Pcr config flag to mask SHA-1 from TPM PCRs

### DIFF
--- a/MsvmPkg/Include/BiosInterface.h
+++ b/MsvmPkg/Include/BiosInterface.h
@@ -789,7 +789,7 @@ typedef struct _UEFI_CONFIG_FLAGS
         UINT64 Dhcp6DuidTypeLlt : 1;
         UINT64 CxlMemoryEnabled : 1;
         UINT64 MtrrsInitializedAtLoad : 1;
-        UINT64 HvSintEnabled : 1;  // Reserved; used by other codebase.
+        UINT64 DisableSha1Pcr : 1;
         UINT64 VmbusDisabled : 1;
         UINT64 PciResourcesPreAssigned : 1;
         UINT64 ForceDmaBounceEnabled : 1;

--- a/MsvmPkg/PlatformPei/Config.c
+++ b/MsvmPkg/PlatformPei/Config.c
@@ -759,6 +759,7 @@ DebugDumpUefiConfigStruct(
             DEBUG((DEBUG_VERBOSE, "\tProcIdleEnabled: %u\n", flags->Flags.ProcIdleEnabled));
             DEBUG((DEBUG_VERBOSE, "\tCxlMemoryEnabled: %u\n", flags->Flags.CxlMemoryEnabled));
             DEBUG((DEBUG_VERBOSE, "\tDisableSha384Pcr: %u\n", flags->Flags.DisableSha384Pcr));
+            DEBUG((DEBUG_VERBOSE, "\tDisableSha1Pcr: %u\n", flags->Flags.DisableSha1Pcr));
             DEBUG((DEBUG_VERBOSE, "\tMediaPresentEnabledByDefault: %u\n", flags->Flags.MediaPresentEnabledByDefault));
             DEBUG((DEBUG_VERBOSE, "\tMemoryProtectionMode: %u\n", flags->Flags.MemoryProtectionMode));
             DEBUG((DEBUG_VERBOSE, "\tWatchdogEnabled: %u\n", flags->Flags.WatchdogEnabled));
@@ -1025,6 +1026,14 @@ ConfigSetUefiConfigFlags(
     if (ConfigFlags->Flags.DisableSha384Pcr)
     {
         PEI_FAIL_FAST_IF_FAILED(PcdSet32S(PcdTpm2HashMask, (PcdGet32(PcdTpm2HashMask) & ~HASH_ALG_SHA384)));
+    }
+
+    //
+    // When DisableSha1Pcr is TRUE, we remove SHA-1 from the PCR hash mask.
+    //
+    if (ConfigFlags->Flags.DisableSha1Pcr)
+    {
+        PEI_FAIL_FAST_IF_FAILED(PcdSet32S(PcdTpm2HashMask, (PcdGet32(PcdTpm2HashMask) & ~HASH_ALG_SHA1)));
     }
 #endif
 


### PR DESCRIPTION
## Summary
Adds a `DisableSha1Pcr` UEFI config flag that, when set by the host, removes the SHA-1 bank from the TPM PCR hash mask (`PcdTpm2HashMask`) at PEI time.

This follows the existing `DisableSha384Pcr` pattern.

## Changes
- **MsvmPkg/Include/BiosInterface.h** — repurpose the previously reserved `HvSintEnabled` bit in `UEFI_CONFIG_FLAGS` as `DisableSha1Pcr`. No new bit is consumed and `Reserved` is unchanged, so the surrounding flag layout/ABI is preserved.
- **MsvmPkg/PlatformPei/Config.c** — in `ConfigSetUefiConfigFlags`, when the flag is set, clear `HASH_ALG_SHA1` from `PcdTpm2HashMask` via `PcdSet32S` (same `MDE_CPU_X64` guard as the SHA-384 path); plus a matching `DEBUG_VERBOSE` log line.

The dynamic PCD `gEfiSecurityPkgTokenSpaceGuid.PcdTpm2HashMask` is already declared in `PlatformPei.inf`, so no INF/DSC changes are required.

## Notes
Default behavior is unchanged (flag defaults to 0). Effective only on X64, matching the existing SHA-384 measured-boot config path.