### PR TITLE
Merged PR 16456095: Configure NVMe generic timeout to 120 seconds

### DIFF
--- a/MsvmPkg/MsvmPkgAARCH64.dsc
+++ b/MsvmPkg/MsvmPkgAARCH64.dsc
@@ -543,6 +543,9 @@
   # Disable front page auto power off
   gMsGraphicsPkgTokenSpaceGuid.PcdPowerOffDelay|0xffffffff
 
+  # Configure NVMe generic timeout to watchdog timeout limit
+  gEfiMdeModulePkgTokenSpaceGuid.PcdNvmeGenericTimeout|120
+
   # Change PcdBootManagerMenuFile to point to the FrontPage application
   gEfiMdeModulePkgTokenSpaceGuid.PcdBootManagerMenuFile|{ 0x8A, 0x70, 0x42, 0x40, 0x2D, 0x0F, 0x23, 0x48, 0xAC, 0x60, 0x0D, 0x77, 0xB3, 0x11, 0x18, 0x89 }
 

--- a/MsvmPkg/MsvmPkgX64.dsc
+++ b/MsvmPkg/MsvmPkgX64.dsc
@@ -553,6 +553,9 @@
   # Enable NVME changes for ASAP devices
   gEfiMdeModulePkgTokenSpaceGuid.PcdSupportAlternativeQueueSize|TRUE
 
+  # Configure NVMe generic timeout to watchdog timeout limit
+  gEfiMdeModulePkgTokenSpaceGuid.PcdNvmeGenericTimeout|120
+
 [PcdsFixedAtBuild.X64]
 !if $(PERF_TRACE_ENABLE) == TRUE
   # 16M should be enough to fit all the verbose measurements


### PR DESCRIPTION
Configures the NVMe timeout to 120 seconds, like the watchdog timeout. This was missed in the previous fast forward change.

----
#### AI description  (iteration 1)
#### PR Classification
Configuration change to align NVMe generic timeout with watchdog timeout limits to address missing upstream timeout configuration.

#### PR Summary
This pull request configures the NVMe generic timeout to 120 seconds for both AARCH64 and X64 platforms to match the watchdog timeout limit and incorporate an upstream change that was previously missing.

- `MsvmPkgAARCH64.dsc`: Added `PcdNvmeGenericTimeout` configuration set to 120 seconds
- `MsvmPkgX64.dsc`: Added `PcdNvmeGenericTimeout` configuration set to 120 seconds <!-- GitOpsUserAgent=GitOps.Apps.Server.pullrequestcopilot -->


Related work items: #62560888