### PR TITLE
EventLogDxe: Remove Circular Dependency

### DIFF
--- a/MsvmPkg/EventLogDxe/EventLogDxe.c
+++ b/MsvmPkg/EventLogDxe/EventLogDxe.c
@@ -74,13 +74,6 @@ Return Value:
     //
     StatusCodeRuntimeInitialize();
 
-    //
-    // Workaroud: Initialize BootEventLogLib library.  This is done because BootEventLogLib
-    //            library requires gEfiEventLogProtocolGuid, which is not available at the
-    //            time of its constructor execution.
-    //
-    BootEventLogLibInit(ImageHandle, SystemTable);
-
 Exit:
 
     return status;

--- a/MsvmPkg/EventLogDxe/EventLogDxe.h
+++ b/MsvmPkg/EventLogDxe/EventLogDxe.h
@@ -9,13 +9,13 @@
 
 #include <Library/BaseLib.h>
 #include <Library/BaseMemoryLib.h>
-#include <Library/BootEventLogLib.h>
 #include <Library/DebugLib.h>
 #include <Library/MemoryAllocationLib.h>
 #include <Library/PcdLib.h>
 #include <Library/UefiBootServicesTableLib.h>
 #include <Library/UefiLib.h>
 
+#include <BiosBootLogInterface.h>
 #include <Protocol/EfiHv.h>
 #include <Protocol/EventLog.h>
 extern EFI_HV_IVM_PROTOCOL *mHvIvm;

--- a/MsvmPkg/EventLogDxe/EventLogDxe.inf
+++ b/MsvmPkg/EventLogDxe/EventLogDxe.inf
@@ -39,7 +39,6 @@
   BaseLib
   BaseMemoryLib
   BiosDeviceLib
-  BootEventLogLib                 # MS_CHANGE
   DevicePathLib                   # MS_CHANGE
   DebugLib
   HobLib
@@ -57,6 +56,7 @@
   gMemoryStatusCodeRecordGuid                   ## CONSUMES ## HOB
   gStatusCodeEventChannelGuid                   ## CONSUMES
   gSyntheticNetworkClassGuid                    ## CONSUMES
+  gBootEventChannelGuid                         ## CONSUMES
 
 [Protocols]
   gEfiEventLogProtocolGuid                      ## PRODUCES
@@ -71,6 +71,7 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdProgressCodeOsLoaderStart               ## SOMETIMES_CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdStatusCodeReplayIn
   gMsvmPkgTokenSpaceGuid.PcdEventLogMaxChannels
+  gMsvmPkgTokenSpaceGuid.PcdBootEventLogSize
   gMsvmPkgTokenSpaceGuid.PcdHostEmulatorsWhenHardwareIsolated
   gMsvmPkgTokenSpaceGuid.PcdIsolationSharedGpaBoundary
   gMsvmPkgTokenSpaceGuid.PcdIsolationSharedGpaCanonicalizationBitmask

--- a/MsvmPkg/EventLogDxe/EventLogger.c
+++ b/MsvmPkg/EventLogDxe/EventLogger.c
@@ -69,6 +69,11 @@ typedef struct
     //
     EVENT_CHANNEL_STATISTICS    Stats;
     //
+    // Pre-allocated below 4GB for the BIOS data port. This buffer is retained
+    // for the channel lifetime so flushing does not change the memory map.
+    //
+    VOID                        *FlushBuffer;
+    //
     // Backing store for event data
     //
     EFI_RING_BUFFER             Ring;
@@ -319,18 +324,13 @@ Return Value:
     UINT64 physicalAddress;
     UINT64 virtualAddress;
     BOOLEAN hostEmulatorsPresent = PcdGetBool(PcdHostEmulatorsWhenHardwareIsolated);
-    VOID* originalAllocation;
 
     //
-    // Allocate a region below 4GB since the BIOS data port
-    // only accepts 32-Bit values.
+    // Use the region allocated when the channel was created. The BIOS data
+    // port only accepts 32-bit addresses, and allocating here would change
+    // the memory map when called from an ExitBootServices notification.
     //
-    channelDescriptor = EventAllocate32BitMemory(allocSize);
-    originalAllocation = channelDescriptor;
-    if (channelDescriptor == NULL)
-    {
-        return EFI_OUT_OF_RESOURCES;
-    }
+    channelDescriptor = channel->FlushBuffer;
 
     EventChannelLock(channel);
 
@@ -405,7 +405,6 @@ Return Value:
 
 Exit:
     EventChannelUnlock(channel);
-    FreePages(originalAllocation, EFI_SIZE_TO_PAGES(allocSize));
 
     return status;
 }
@@ -586,6 +585,8 @@ Return Value:
     EFI_HANDLE    handle   = INVALID_EVENT_HANDLE;
     UINTN         allocSize;
     EFI_STATUS    status;
+    UINT32        flushBufferSize;
+    VOID          *flushBuffer = NULL;
 
     //
     // Try to find the channel.
@@ -630,17 +631,39 @@ Return Value:
         goto Exit;
     }
 
+    if (Attributes->BufferSize > (MAX_UINT32 - sizeof(BIOS_EVENT_CHANNEL)))
+    {
+        status = EFI_BAD_BUFFER_SIZE;
+        goto Exit;
+    }
+
+    //
+    // Pre-allocate the flush buffer below 4GB for the BIOS data port. We
+    // allocate it here so that we can safe during EBS when we cannot
+    // tolerate memory map changes. It is boot services data and will be
+    // released to the OS after EBS.
+    //
+    flushBufferSize = Attributes->BufferSize + sizeof(BIOS_EVENT_CHANNEL);
+    flushBuffer = EventAllocate32BitMemory(flushBufferSize);
+    if (flushBuffer == NULL)
+    {
+        status = EFI_OUT_OF_RESOURCES;
+        goto Exit;
+    }
+
     allocSize = sizeof(EVENT_CHANNEL) + Attributes->BufferSize;
 
     status = EfiHandleTableAllocateObject(mEventChannels, allocSize, (void**)&channel, &handle);
 
     if (EFI_ERROR(status))
     {
+        FreePages(flushBuffer, EFI_SIZE_TO_PAGES(flushBufferSize));
         goto Exit;
     }
 
     CopyGuid(&channel->Id, Channel);
     CopyMem(&channel->Attributes, Attributes, sizeof(channel->Attributes));
+    channel->FlushBuffer = flushBuffer;
 
     EfiInitializeLock(&channel->Lock, Attributes->Tpl);
     channel->Pending.Handle    = INVALID_RING_HANDLE;

--- a/MsvmPkg/EventLogDxe/StatusCode.c
+++ b/MsvmPkg/EventLogDxe/StatusCode.c
@@ -35,9 +35,11 @@ ReportStatusCode(
 //
 // GUID for status code event channel.
 //
+extern EFI_GUID gBootEventChannelGuid;
 extern EFI_GUID gStatusCodeEventChannelGuid;
 
 EFI_HANDLE  mEfiStatusCodeEventHandle;
+STATIC EFI_HANDLE  mBootEvent = INVALID_EVENT_HANDLE;
 
 //
 // CallerId field is valid.
@@ -59,6 +61,114 @@ typedef struct
     EFI_GUID                CallerId;
     EFI_STATUS_CODE_DATA    Data;
 } EFI_STATUS_CODE_EVENT;
+
+
+STATIC
+VOID
+BootEventChannelInitialize (
+  VOID
+  )
+{
+    EVENT_CHANNEL_INFO Attributes;
+
+    Attributes.Flags      = 0;
+    Attributes.RecordSize = 0;
+    Attributes.BufferSize = PcdGet32 (PcdBootEventLogSize);
+    Attributes.Tpl        = TPL_NOTIFY;
+    (VOID)EventChannelCreate (&gBootEventChannelGuid, &Attributes, &mBootEvent);
+}
+
+
+STATIC
+EFI_STATUS
+BootDeviceEventStart (
+  IN CONST EFI_DEVICE_PATH_PROTOCOL  *DevicePath,
+  IN UINT16                          BootVariableNumber,
+  IN BOOT_DEVICE_STATUS              InitialStatus,
+  IN EFI_STATUS                      ExtendedStatus
+  )
+{
+    BOOTEVENT_DEVICE_ENTRY  *BootEvent;
+    EFI_EVENT_DESCRIPTOR    EventDescriptor;
+    UINTN                   DevicePathSize;
+    EFI_STATUS              Status;
+
+    if (mBootEvent == INVALID_EVENT_HANDLE) {
+        return EFI_NOT_READY;
+    }
+
+    DevicePathSize = GetDevicePathSize (DevicePath);
+    ASSERT (DevicePathSize < PcdGet32 (PcdBootEventLogSize));
+
+    BootEvent = AllocateZeroPool (DevicePathSize + sizeof (BOOTEVENT_DEVICE_ENTRY));
+    if (BootEvent == NULL) {
+        return EFI_OUT_OF_RESOURCES;
+    }
+
+    BootEvent->Status             = InitialStatus;
+    BootEvent->ExtendedStatus     = ExtendedStatus;
+    BootEvent->DevicePathSize     = (UINT32)DevicePathSize;
+    BootEvent->BootVariableNumber = BootVariableNumber;
+    CopyMem (BootEvent->DevicePath, DevicePath, DevicePathSize);
+
+    ZeroMem (&EventDescriptor, sizeof (EventDescriptor));
+    EventDescriptor.Flags    = EVENT_FLAG_PENDING;
+    EventDescriptor.EventId  = BOOT_DEVICE_EVENT_ID;
+    EventDescriptor.DataSize = (UINT32)(DevicePathSize + sizeof (BOOTEVENT_DEVICE_ENTRY));
+    Status = EventLog (mBootEvent, &EventDescriptor, BootEvent);
+
+    FreePool (BootEvent);
+    return Status;
+}
+
+
+STATIC
+EFI_STATUS
+BootDeviceEventUpdate (
+  IN BOOT_DEVICE_STATUS  Status,
+  IN EFI_STATUS          ExtendedStatus
+  )
+{
+    BOOTEVENT_DEVICE_ENTRY  *BootEvent;
+    EFI_EVENT_DESCRIPTOR    EventDescriptor;
+    EFI_STATUS              EventStatus;
+
+    if (mBootEvent == INVALID_EVENT_HANDLE) {
+        return EFI_NOT_READY;
+    }
+
+    EventStatus = EventPendingGet (mBootEvent, &EventDescriptor, (VOID **)&BootEvent);
+    if (EFI_ERROR (EventStatus)) {
+        return EventStatus;
+    }
+
+    if (EventDescriptor.EventId != BOOT_DEVICE_EVENT_ID) {
+        return EFI_NOT_FOUND;
+    }
+
+    if (EventDescriptor.DataSize < sizeof (BOOTEVENT_DEVICE_ENTRY)) {
+        ASSERT (FALSE);
+        return EFI_INVALID_PARAMETER;
+    }
+
+    BootEvent->Status         = Status;
+    BootEvent->ExtendedStatus = ExtendedStatus;
+    return EFI_SUCCESS;
+}
+
+
+STATIC
+EFI_STATUS
+BootDeviceEventComplete (
+  VOID
+  )
+{
+    if (mBootEvent == INVALID_EVENT_HANDLE) {
+        return EFI_NOT_READY;
+    }
+
+    return EventPendingCommit (mBootEvent);
+}
 
 
 /**
@@ -392,6 +502,12 @@ Return Value:
         ASSERT(FALSE);
         goto Exit;
     }
+
+    //
+    // EventLogDxe owns the event logger implementation, so use it directly
+    // rather than calling back through BootEventLogLib and the protocol.
+    //
+    BootEventChannelInitialize ();
 
     //
     // Replay Status code entries which were logged during the PEI phase.

--- a/MsvmPkg/Library/EventLogLib/EventLogLib.inf
+++ b/MsvmPkg/Library/EventLogLib/EventLogLib.inf
@@ -35,3 +35,6 @@
 
 [Protocols]
   gEfiEventLogProtocolGuid      ## CONSUMES
+
+[Depex]
+  gEfiEventLogProtocolGuid


### PR DESCRIPTION
Currently, EventLogDxe depends on BootEventLogLib, which depends on EventLogLib, which depends on the protocol produced by EventLogDxe.

This circular dependency worked when an APRIORI file was present forcing EventLogDxe to be dispatched first, but it is incorrect layering and breaks when APRIORI is removed. Other consumers of BootEventLogLib fail to log events because the underlying protocol might not be available when they come up.

To fix this, the circular dependency must be broken: EventLogDxe cannot depend on BootEventLogLib. The small amount of functionality it was depending on is duplicated here for status code routing. Now a proper depex can be added to EventLogLib to ensure the protocol is produced before the library's module is loaded.