### PR TITLE
Disable interrupts around multiple MmioRead32 calls and similar.

### DIFF
--- a/MsvmPkg/Library/BiosDeviceDebugLib/DebugLib.c
+++ b/MsvmPkg/Library/BiosDeviceDebugLib/DebugLib.c
@@ -40,6 +40,7 @@ WriteBiosDevice (
   )
 {
   UINTN  biosBaseAddress = PcdGet32 (PcdBiosBaseAddress);
+  BOOLEAN interruptState = SaveAndDisableInterrupts ();
 
  #if defined (MDE_CPU_AARCH64)
   MmioWrite32 (biosBaseAddress, AddressRegisterValue);
@@ -48,6 +49,8 @@ WriteBiosDevice (
   IoWrite32 (biosBaseAddress, AddressRegisterValue);
   IoWrite32 (biosBaseAddress + 4, DataRegisterValue);
  #endif
+
+  SetInterruptState (interruptState);
 }
 
 static
@@ -57,14 +60,18 @@ ReadBiosDevice (
   )
 {
   UINTN  biosBaseAddress = PcdGet32 (PcdBiosBaseAddress);
+  BOOLEAN interruptState = SaveAndDisableInterrupts ();
 
  #if defined (MDE_CPU_AARCH64)
   MmioWrite32 (biosBaseAddress, AddressRegisterValue);
-  return MmioRead32 (biosBaseAddress + 4);
+  UINT32 result = MmioRead32 (biosBaseAddress + 4);
  #elif defined (MDE_CPU_X64)
   IoWrite32 (biosBaseAddress, AddressRegisterValue);
-  return IoRead32 (biosBaseAddress + 4);
+  UINT32 result = IoRead32 (biosBaseAddress + 4);
  #endif
+
+  SetInterruptState (interruptState);
+  return result;
 }
 
 VOID

--- a/MsvmPkg/Library/BiosDeviceLib/BiosDeviceLibCore.c
+++ b/MsvmPkg/Library/BiosDeviceLib/BiosDeviceLibCore.c
@@ -38,6 +38,8 @@ WriteBiosDevice (
   IN UINT32  DataRegisterValue
   )
 {
+  BOOLEAN interruptState = SaveAndDisableInterrupts ();
+
  #if _USING_BIOS_MMIO_
   MmioWrite32 (mBiosBaseAddress, AddressRegisterValue);
   MmioWrite32 (mBiosBaseAddress + 4, DataRegisterValue);
@@ -45,6 +47,8 @@ WriteBiosDevice (
   IoWrite32 (mBiosBaseAddress, AddressRegisterValue);
   IoWrite32 (mBiosBaseAddress + 4, DataRegisterValue);
  #endif
+
+  SetInterruptState (interruptState);
 }
 
 UINT32
@@ -52,11 +56,16 @@ ReadBiosDevice (
   IN UINT32  AddressRegisterValue
   )
 {
+  BOOLEAN interruptState = SaveAndDisableInterrupts ();
+
  #if _USING_BIOS_MMIO_
   MmioWrite32 (mBiosBaseAddress, AddressRegisterValue);
-  return MmioRead32 (mBiosBaseAddress + 4);
+  UINT32 result = MmioRead32 (mBiosBaseAddress + 4);
  #else
   IoWrite32 (mBiosBaseAddress, AddressRegisterValue);
-  return IoRead32 (mBiosBaseAddress + 4);
+  UINT32 result = IoRead32 (mBiosBaseAddress + 4);
  #endif
+
+  SetInterruptState (interruptState);
+  return result;
 }

--- a/MsvmPkg/Library/Tpm2DeviceLib/Tpm2DeviceLib.c
+++ b/MsvmPkg/Library/Tpm2DeviceLib/Tpm2DeviceLib.c
@@ -106,6 +106,8 @@ WriteTpmPort (
   IN UINT32  DataRegisterValue
   )
 {
+  BOOLEAN interruptState = SaveAndDisableInterrupts ();
+
  #if defined (MDE_CPU_AARCH64)
   UINT64  Port = FixedPcdGet64 (PcdTpmBaseAddress) + 0x80;
   MmioWrite32 (Port, AddressRegisterValue);
@@ -114,6 +116,8 @@ WriteTpmPort (
   IoWrite32 (TpmControlPort, AddressRegisterValue);
   IoWrite32 (TpmDataPort, DataRegisterValue);
  #endif
+
+  SetInterruptState (interruptState);
 }
 
 UINT32
@@ -121,14 +125,19 @@ ReadTpmPort (
   IN UINT32  AddressRegisterValue
   )
 {
+  BOOLEAN interruptState = SaveAndDisableInterrupts ();
+
  #if defined (MDE_CPU_AARCH64)
   UINT64  Port = FixedPcdGet64 (PcdTpmBaseAddress) + 0x80;
-  MmioWrite32 (Port, AddressRegisterValue);
+  UINT32 result = MmioWrite32 (Port, AddressRegisterValue);
   return MmioRead32 (Port + 4);
  #elif defined (MDE_CPU_X64)
   IoWrite32 (TpmControlPort, AddressRegisterValue);
-  return IoRead32 (TpmDataPort);
+  UINT32 result = IoRead32 (TpmDataPort);
  #endif
+
+  SetInterruptState (interruptState);
+  return result;
 }
 
 EFI_STATUS

--- a/MsvmPkg/PlatformPei/Platform.c
+++ b/MsvmPkg/PlatformPei/Platform.c
@@ -162,6 +162,7 @@ WriteBiosDevice (
   )
 {
   UINTN  biosBaseAddress = PcdGet32 (PcdBiosBaseAddress);
+  BOOLEAN interruptState = SaveAndDisableInterrupts ();
 
  #if defined (MDE_CPU_AARCH64)
   MmioWrite32 (biosBaseAddress, AddressRegisterValue);
@@ -170,6 +171,8 @@ WriteBiosDevice (
   IoWrite32 (biosBaseAddress, AddressRegisterValue);
   IoWrite32 (biosBaseAddress + 4, DataRegisterValue);
  #endif
+
+  SetInterruptState (interruptState);
 }
 
 static
@@ -179,14 +182,18 @@ ReadBiosDevice (
   )
 {
   UINTN  biosBaseAddress = PcdGet32 (PcdBiosBaseAddress);
+  BOOLEAN interruptState = SaveAndDisableInterrupts ();
 
  #if defined (MDE_CPU_AARCH64)
   MmioWrite32 (biosBaseAddress, AddressRegisterValue);
-  return MmioRead32 (biosBaseAddress + 4);
+  UINT32 result = MmioRead32 (biosBaseAddress + 4);
  #elif defined (MDE_CPU_X64)
   IoWrite32 (biosBaseAddress, AddressRegisterValue);
-  return IoRead32 (biosBaseAddress + 4);
+  UINT32 result = IoRead32 (biosBaseAddress + 4);
  #endif
+
+  SetInterruptState (interruptState);
+  return result;
 }
 
 #if defined (MDE_CPU_X64)


### PR DESCRIPTION
There are race conditions of the form:
 MmioWrite(port, x)
 MmioWrite(port2, y)

These need to occur one after the other without interrupt.
In case an interrupt writes to one of the ports.

Disable interrupts around such sequences.