### PR TITLE
CI: Enforce stuart_ci

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -2,4 +2,4 @@
 02733154b022b3fc10760d2fd18a31e8376b77ee
 
 # Apply Uncrustify formatting
-6aab02defa4cc2072cf35adc2c335b5a47f15030
+7bd23823f22cfeafd753c3f36e0aecd3d2b00e15

--- a/.pytool/CISettings.py
+++ b/.pytool/CISettings.py
@@ -6,10 +6,12 @@
 ##
 
 import logging
-import os
+from pathlib import Path
 
 from edk2toolext.invocables.edk2_ci_build import CiBuildSettingsManager
 from edk2toolext.invocables.edk2_update import UpdateSettingsManager
+
+WORKSPACE_ROOT = str(Path(__file__).parent.parent)
 
 
 class Settings(CiBuildSettingsManager, UpdateSettingsManager):
@@ -55,16 +57,10 @@ class Settings(CiBuildSettingsManager, UpdateSettingsManager):
         return []
 
     def GetPackagesPath(self):
-        workspace = self.GetWorkspaceRoot()
-        return [
-            workspace,
-            os.path.join(workspace, "MU_BASECORE"),
-            os.path.join(workspace, "Common/MU"),
-            os.path.join(workspace, "Feature/DEBUGGER"),
-        ]
+        return (".", "MU_BASECORE", "Common/MU", "Feature/DEBUGGER")
 
     def GetWorkspaceRoot(self):
-        return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        return WORKSPACE_ROOT
 
     def GetName(self):
         return "MuMsvmSourceChecks"

--- a/.pytool/CISettings.py
+++ b/.pytool/CISettings.py
@@ -56,8 +56,12 @@ class Settings(CiBuildSettingsManager, UpdateSettingsManager):
 
     def GetPackagesPath(self):
         workspace = self.GetWorkspaceRoot()
-        package_roots = ("", "MU_BASECORE", "Common/MU", "Feature/DEBUGGER")
-        return [os.path.join(workspace, path) for path in package_roots]
+        return [
+            workspace,
+            os.path.join(workspace, "MU_BASECORE"),
+            os.path.join(workspace, "Common/MU"),
+            os.path.join(workspace, "Feature/DEBUGGER"),
+        ]
 
     def GetWorkspaceRoot(self):
         return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/MsvmPkg/Docs/BUILDING.md
+++ b/MsvmPkg/Docs/BUILDING.md
@@ -26,6 +26,54 @@ stuart_build -c .\MsvmPkg\PlatformBuild.py TARGET=RELEASE
 stuart_build -c .\MsvmPkg\PlatformBuild.py BUILD_ARCH=AARCH64
 ```
 
+## Running CI Checks Locally
+
+Run the source checks from the repository root before opening a pull request. Install the Python dependencies and download the
+tools used by the checks on a new checkout or whenever their configuration changes:
+
+```powershell
+python -m pip install -r pip_requirement_stable.txt
+stuart_update -c .\.pytool\CISettings.py
+```
+
+Run the same source checks enforced by GitHub Actions:
+
+```powershell
+stuart_ci_build `
+	-c .\.pytool\CISettings.py `
+	-p MsvmPkg `
+	-t NO-TARGET `
+	-a X64,AARCH64 `
+	--disable-all `
+	GuidCheck=run `
+	LineEndingCheck=run `
+	UncrustifyCheck=run
+```
+
+The `--disable-all` option disables the default plugin set; each `Check=run` argument enables a check used by this repository.
+To run one check while iterating, specify only that check. For example:
+
+```powershell
+stuart_ci_build -c .\.pytool\CISettings.py -p MsvmPkg -t NO-TARGET -a X64,AARCH64 --disable-all GuidCheck=run
+```
+
+### Fixing Uncrustify Failures
+
+Run Uncrustify in correction mode to update incorrectly formatted files in place:
+
+```powershell
+stuart_ci_build `
+	-c .\.pytool\CISettings.py `
+	-p MsvmPkg `
+	-t NO-TARGET `
+	-a X64,AARCH64 `
+	--disable-all `
+	UncrustifyCheck=run `
+	UNCRUSTIFY_IN_PLACE=TRUE
+```
+
+Review the resulting changes and rerun the full source-check command before committing them.
+
 ## Specialized Builds
 
 ### Debug-Enabled Build

--- a/MsvmPkg/Docs/DEVGUIDE.md
+++ b/MsvmPkg/Docs/DEVGUIDE.md
@@ -5,10 +5,11 @@ MsvmPkg provides UEFI firmware for Microsoft's virtualization platforms, includi
 ## Getting Started
 
 1. **[Building](BUILDING.md)** - Build UEFI firmware images
-2. **[Firmware Deployment](FIRMWARE-DEPLOYMENT.md)** - Load custom firmware on different platforms
-3. **[Debugging](DEBUGGING.md)** - Interactive UEFI debugging with WinDbg
-4. **[Logging](LOGGING.md)** - Collect UEFI logs and diagnostics
-5. **[Advanced](ADVANCED.md)** - Graphics, UEFI Shell, and experimental features
+2. **[Running CI Locally](BUILDING.md#running-ci-checks-locally)** - Run source checks before opening a pull request
+3. **[Firmware Deployment](FIRMWARE-DEPLOYMENT.md)** - Load custom firmware on different platforms
+4. **[Debugging](DEBUGGING.md)** - Interactive UEFI debugging with WinDbg
+5. **[Logging](LOGGING.md)** - Collect UEFI logs and diagnostics
+6. **[Advanced](ADVANCED.md)** - Graphics, UEFI Shell, and experimental features
 
 ## Platform Support
 

--- a/MsvmPkg/MsvmPkg.ci.yaml
+++ b/MsvmPkg/MsvmPkg.ci.yaml
@@ -39,7 +39,7 @@
         "IgnoreFilesWithNoExtension": false
     },
     "UncrustifyCheck": {
-        "AuditOnly": true,
+        "AuditOnly": false,
         "IgnoreFiles": [],
         "OutputFileDiffs": false
     }


### PR DESCRIPTION
Enforce stuart_ci plugins so that changes are gated until stuart_ci passes. This also updates the `git-blame-ignore-revs` to point to the previous PR's squashed commit.